### PR TITLE
Overhaul Parrot-AI as conversation learning app

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,4 @@
-name: CI/CD
+name: CI
 
 on:
   push:
@@ -7,98 +7,31 @@ on:
     branches: [ main, dev ]
 
 jobs:
-  test:
+  web:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+
+    - name: Set up Node
+      uses: actions/setup-node@v4
       with:
-        python-version: '3.8'
+        node-version: '24'
+        cache: npm
+
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r backend/requirements.txt -r frontend/requirements.txt
-        pip install flake8 black pytest
-    - name: Format with black
-      run: |
-        black --version
-        black .
-        black --check .
-    - name: Lint with flake8
-      run: |
-        flake8 --version
-        flake8 .
-    - name: Run tests
-      run: pytest
+      run: npm ci
 
-  build-and-push:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
-    
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    
-    - name: Build and push backend image
-      uses: docker/build-push-action@v4
-      with:
-        context: ./backend
-        push: true
-        tags: ghcr.io/${{ github.repository }}/parrot-ai-backend:latest
-    
-    - name: Build and push frontend image
-      uses: docker/build-push-action@v4
-      with:
-        context: ./frontend
-        push: true
-        tags: ghcr.io/${{ github.repository }}/parrot-ai-frontend:latest
+    - name: Typecheck
+      run: npm run typecheck
 
-    - name: Lint Dockerfile
-      uses: hadolint/hadolint-action@v3.1.0
-      with:
-        dockerfile: ./backend/Dockerfile
+    - name: Unit and integration tests
+      run: npm test
 
-    - name: Lint Dockerfile
-      uses: hadolint/hadolint-action@v3.1.0
-      with:
-        dockerfile: ./frontend/Dockerfile
+    - name: Production build
+      run: npm run build
 
-  evaluate:
-    needs: [test, build-and-push]
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.8'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-    - name: Run evaluation
-      run: python evaluate.py
-    - name: Upload evaluation results
-      uses: actions/upload-artifact@v3
-      with:
-        name: evaluation-results
-        path: EVALUATION_RESULTS.md
+    - name: Install Playwright browsers
+      run: npx playwright install --with-deps chromium
 
-  deploy:
-    needs: build-and-push
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    steps:
-    - name: Deploy to production
-      run: |
-        echo "Deploying to production..."
-        # Add deployment steps here
+    - name: Browser tests
+      run: npm run e2e

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 src/venv
 .env
+.env.local
+.env.*.local
 src/__pycache__
 .pytest_cache
 tests/__pycache__
@@ -12,3 +14,12 @@ coverage.xml
 .coverage
 .DS_Store
 tests/.DS_Store
+node_modules/
+.next/
+out/
+dist/
+build/
+tsconfig.tsbuildinfo
+playwright-report/
+test-results/
+coverage/

--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ npm run e2e
 
 Playwright starts the local Next.js dev server automatically for browser tests.
 
+## Production Readiness
+
+This branch is ready for a first production-style deployment of the web app, with these boundaries:
+
+- The app has request validation, structured tutor responses, basic per-instance API rate limiting, security headers, browser E2E coverage, and a health endpoint at `/api/health`.
+- The default tutor is deterministic demo mode, so the app works without paid API keys.
+- Browser speech uses the user's browser capabilities and can vary by device, browser, and language.
+- Stronger production controls still need external services: hosted rate limiting, auth, analytics, persistent user accounts, and a managed AI/voice provider for high-quality real-time speech.
+
 ## Planning Docs
 
 The overhaul planning docs live in `docs/overhaul/`:

--- a/README.md
+++ b/README.md
@@ -1,269 +1,98 @@
-# Parrot-AI🦜🌍: AI-Powered Language Learning Conversation Generator
+# Parrot-AI
 
-![Build Status](https://github.com/mrinoybanerjee/parrot-ai/actions/workflows/ci-cd.yml/badge.svg)
-![Coverage](https://img.shields.io/badge/coverage-85%25-brightgreen)
-![License](https://img.shields.io/badge/license-MIT-blue)
+Parrot-AI is a conversation-first language learning app. The overhaul moves the project from a Streamlit proof of concept to a production-oriented Next.js app focused on live speaking practice, scenario simulation, cultural context, and repair-based coaching.
 
-Parrot-AI is an AI-powered language learning tool that generates conversation and debate scripts. It uses a Streamlit frontend, a FastAPI backend, and leverages local Large Language Models to offer a personalized and interactive learning experience without relying on external APIs.
+The core product idea is simple: the learner should practice by applying the language in realistic conversations, not by only memorizing isolated phrases.
 
-## 🎯 Project Purpose
+## Current App
 
-Parrot-AI aims to provide language learners with an immersive tool to practice conversations and debates in their target language. By utilizing local Large Language Models, it offers a customized and interactive learning experience that adapts to the user's proficiency level and learning preferences.
+- Scenario Studio for configuring language, level, role, goal, intensity, and cultural focus.
+- Conversation Workspace with typed input, browser speech recognition when available, and speech playback.
+- Learning Coach with corrections, repaired phrases, phrase bank additions, and session scores.
+- Provider-pluggable tutor backend with a deterministic fallback provider and optional local Ollama-compatible chat model support.
+- Unit, integration, and Playwright browser tests for the new web app.
 
-## 💡 Motivation
+The old Streamlit/FastAPI files are still in the repository as legacy reference code. The active app path is the Next.js app at the repo root.
 
-The idea for Parrot-AI was born from personal travel experiences, which highlighted the importance of language in forming deep connections with locals. Traditional language learning apps weren't providing the immersive experience needed for effective learning. Parrot-AI fills this gap by offering a more conversational and context-rich approach to language learning.
+## Tech Stack
 
-## 🌟 Features
+- Next.js 16 App Router
+- React 19
+- TypeScript 6
+- Zod for request and response validation
+- Browser Web Speech APIs for free speech recognition and playback where supported
+- Optional Ollama-compatible local LLM provider
+- Vitest and Testing Library
+- Playwright
 
-- 🌍 Supports multiple languages: English, Hindi, German, Spanish, French
-- 💬 Two learning modes: Conversation and Debate
-- 📊 Adjustable proficiency levels and session lengths
-- 🔊 Text-to-speech functionality
-- 🔄 Translation support
-- 🖥️ Local LLM integration for privacy and customization
-
-## 🌴 Project Structure
-
-```
-parrot-ai/
-│
-├── backend/
-│   ├── Dockerfile
-│   ├── app.py
-│   ├── requirements.txt
-│   └── src/
-│       ├── __init__.py
-│       ├── chatbot.py
-│       └── utils.py
-│
-├── frontend/
-│   ├── Dockerfile
-│   ├── app.py
-│   ├── requirements.txt
-│   └── src/
-│       ├── __init__.py
-│       ├── conversation.py
-│       └── utils.py
-│
-├── tests/
-|   ├── Dockerfile
-│   ├── backend/
-│   │   ├── test_chatbot.py
-│   │   └── test_utils.py
-│   └── frontend/
-│       ├── test_conversation.py
-│       └── test_utils.py
-│
-├── .github/
-│   └── workflows/
-│       └── ci-cd.yml
-├── assets/
-│   └── architecture_diagram.png
-├── .gitignore
-├── docker-compose.yml
-├── LICENSE
-├── README.md
-├── conftest.py
-├── evaluate.py
-└── pytest.ini
-
-```
-
-## 🏛 Architecture
-
-Parrot-AI uses a containerized microservices architecture. The diagram below illustrates the main components and their interactions:
-
-![Parrot-AI Architecture Diagram](assets/architecture_diagram.png)
-
-Key components:
-- Frontend: Streamlit-based user interface
-- Backend: FastAPI server handling business logic
-- Docker: Containerization of frontend and backend services
-- LLM: Local language model (llamafile) for generating responses
-
-
-## 🚀 Quick Start
-
-### Prerequisites
-
-- Docker and Docker Compose
-- [llamafile](https://github.com/Mozilla-Ocho/llamafile) (Mistral Instruct 7B)
-
-### Installation and Setup
-
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/mrinoybanerjee/parrot-ai.git
-   cd parrot-ai
-   ```
-
-2. Download and set up llamafile (Mistral Instruct 7B):
-   - Download from [llamafile releases](https://github.com/Mozilla-Ocho/llamafile/releases)
-   - Make it executable:
-     ```bash
-     chmod +x mistral-7b-instruct-v0.2.Q4_0.llamafile
-     ```
-
-3. Build the Docker images:
-   ```bash
-   docker-compose build
-   ```
-
-## 🖥️ Usage
-
-1. Start the llamafile server:
-
-   ```bash
-   ./mistral-7b-instruct-v0.2.Q4_0.llamafile --server --host 0.0.0.0 --port 8080
-   ```
-
-2. Start the Parrot-AI services:
-
-   ```bash
-   docker-compose up
-   ```
-
-3. Open your web browser and navigate to `http://localhost:8501`
-
-![Application Home Page](assets/homepage.png)
-
-4. Configure your session in the sidebar:
-   - Choose learning mode (Conversation or Debate)
-   - Select target language, proficiency level, and session length
-   - For Conversation mode: input roles and actions
-   - For Debate mode: input the debate topic
-
-![Session Configuration](assets/spanish.png)
-
-5. Click "Generate" to create your language learning script
-
-6. Scroll to the bottom of the generated conversation to see key learning points
-
-![Key Learning Points](assets/summary.png)
-
-6. Use the provided buttons to translate, show original text, or play audio
-
-![Translate To English](assets/translate_to_english.png)
-
-![Play Audio](assets/play_audio.png)
-
-
-## 🧪 Running Tests
-
-To run the tests using Docker:
+## Quick Start
 
 ```bash
-docker-compose run test
+npm install
+npm run dev
 ```
 
-This will run the test suite and generate a coverage report.
+Open `http://localhost:3000`.
 
-## Performance and Evaluation
+The app works without paid API keys by using the deterministic fallback tutor. For a better local AI experience, install a chat model in Ollama and run:
 
-Parrot-AI undergoes regular automated evaluations to ensure high-quality performance. Our evaluation process measures several key metrics:
-
-- **Latency**: The time taken to generate responses.
-- **Output Speed**: The rate at which the model generates tokens.
-- **Cosine Similarity**: Measures how well the generated responses align with the expected outputs.
-- **Levenshtein Distance**: Evaluates the degree of difference between the generated responses and expected outputs.
-- **Load Testing**: The system's performance under concurrent requests.
-
-### Latest Evaluation Results
-
-For the most up-to-date evaluation results, please see our [EVALUATION_RESULTS.md](EVALUATION_RESULTS.md) file.
-
-#### Key Metrics Overview:
-
-- **Average Latency**: Measures the responsiveness of the system.
-- **Average Output Speed**: Indicates the efficiency of the model in generating tokens.
-- **Average Cosine Similarity Score**: Shows the relevancy and alignment of the generated responses with the expected outputs.
-- **Average Levenshtein Distance**: Indicates the textual similarity between generated responses and expected outputs.
-
-#### Load Test Performance:
-
-- **Average Response Time**: The average time taken to respond under load.
-- **95th Percentile Response Time**: The response time under load for 95% of the requests, ensuring performance consistency under high demand.
-
-These metrics are continuously monitored in order to improve with each update to Parrot-AI. Our automated evaluation process, integrated into our CI/CD pipeline, ensures that every change is thoroughly tested for performance impacts.
-
-### Running Evaluations Locally
-
-To run the evaluation script locally:
-
-1. Install all requirements:
 ```bash
-pip install -r requirements.txt
+ollama pull qwen3:8b
+OLLAMA_MODEL=qwen3:8b npm run dev
 ```
-2. Ensure Parrot-AI is running (both backend and frontend).
-3. Run the following command:
+
+Optional environment variables:
+
 ```bash
-python evaluate.py
+TUTOR_PROVIDER=fallback
+TUTOR_PROVIDER=ollama
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=qwen3:8b
 ```
-4. The results will be saved in `EVALUATION_RESULTS.md` and logged to the console.
 
-## Demo Video
+When `TUTOR_PROVIDER` is not set, the app attempts Ollama if an Ollama model is configured and falls back cleanly if the local model is unavailable or returns malformed output.
 
-[Demo Video](https://youtu.be/XQmrTN0QzQQ)
+## Testing
 
-## 🛠️ Development
+```bash
+npm run typecheck
+npm test
+npm run build
+npm run e2e
+```
 
-For local development without Docker:
+Playwright starts the local Next.js dev server automatically for browser tests.
 
-1. Set up a virtual environment:
-   ```bash
-   python -m venv venv
-   source venv/bin/activate  # On Windows, use `venv\Scripts\activate`
-   ```
+## Planning Docs
 
-2. Install dependencies:
-   ```bash
-   pip install -r backend/requirements.txt -r frontend/requirements.txt
-   pip install pytest pytest-cov
-   ```
+The overhaul planning docs live in `docs/overhaul/`:
 
-3. Run tests:
-   ```bash
-   pytest
-   ```
+- `research-voice-llm-stack.md`
+- `product-design-spec.md`
+- `engineering-plan.md`
+- `test-plan.md`
 
+These capture the provider research, product direction, implementation architecture, and verification strategy for the production app.
 
-## 🚀 Bonus: Embracing FastAPI
+## Product Direction
 
-For Parrot-AI's backend, I decided to step out of my comfort zone and learn FastAPI, despite my familiarity with Flask. This choice represented a calculated risk to explore modern API development practices. Here's why FastAPI proved to be an excellent decision:
+Parrot-AI should become an application-based language tutor:
 
-1. **High Performance**: FastAPI's speed rivals Go and NodeJS, crucial for our real-time conversation generation.
+- The user enters or selects a real-world scenario.
+- The app plays a believable conversation partner.
+- The tutor pushes the learner to respond in the target language.
+- Feedback is short, concrete, and immediately reusable.
+- Cultural context is part of every exchange, not an afterthought.
 
-2. **Automatic Documentation**: Unlike Flask, FastAPI generates interactive API docs (Swagger UI) out-of-the-box, streamlining our development process.
+The default operating mode should stay cheap and private-friendly. Paid providers can be added behind adapters when quality, latency, or production reliability requires them.
 
-3. **Type Safety**: FastAPI's use of Python type hints enhanced code reliability and IDE support.
+## Legacy App
 
-4. **Native Asynchronous Support**: While Flask requires extensions for async operations, FastAPI's built-in async capabilities future-proof our application.
+The original project used:
 
-While Flask would have been a comfortable choice, adopting FastAPI pushed me to grow as a developer and resulted in a more robust, future-ready backend for Parrot-AI.
+- Streamlit frontend
+- FastAPI backend
+- Docker Compose
+- Local llamafile model experiments
 
-
-## 🤝 Contributing
-
-Contributions are welcome! Please feel free to submit a Pull Request.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/AmazingFeature`)
-3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
-4. Push to the branch (`git push origin feature/AmazingFeature`)
-5. Open a Pull Request
-
-## 📜 License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## 🙏 Acknowledgments
-
-- [Streamlit](https://streamlit.io/) for the frontend framework
-- [FastAPI](https://fastapi.tiangolo.com/) for the backend API
-- [llamafile](https://github.com/Mozilla-Ocho/llamafile) for local LLM support
-- All contributors and supporters of the project
-
-## 📬 Contact
-
-Mrinoy Banerjee - [mrinoybanerjee@gmail.com]
+Those files remain for reference while the Next.js app becomes the main product surface.

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { getProviderName } from "@/lib/tutor/provider";
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    provider: getProviderName(),
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/app/api/tutor/status/route.ts
+++ b/app/api/tutor/status/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { getProviderName } from "@/lib/tutor/provider";
+
+export async function GET() {
+  const provider = getProviderName();
+  const status = {
+    provider,
+    ollamaModel: process.env.OLLAMA_MODEL ?? null,
+    speech: "browser",
+  };
+
+  return NextResponse.json(status);
+}

--- a/app/api/tutor/turn/route.ts
+++ b/app/api/tutor/turn/route.ts
@@ -1,8 +1,27 @@
 import { NextResponse } from "next/server";
 import { tutorTurnRequestSchema } from "@/lib/domain";
+import { checkRateLimit, getClientIp } from "@/lib/server/rate-limit";
 import { runTutorProvider } from "@/lib/tutor/provider";
 
 export async function POST(request: Request) {
+  const rateLimit = checkRateLimit(getClientIp(request));
+  const rateLimitHeaders = {
+    "X-RateLimit-Remaining": String(rateLimit.remaining),
+    "X-RateLimit-Reset": String(Math.ceil(rateLimit.resetAt / 1000)),
+  };
+  if (!rateLimit.allowed) {
+    return NextResponse.json(
+      { error: "Too many tutor requests. Please wait and try again." },
+      {
+        headers: {
+          ...rateLimitHeaders,
+          "Retry-After": String(Math.max(1, Math.ceil((rateLimit.resetAt - Date.now()) / 1000))),
+        },
+        status: 429,
+      },
+    );
+  }
+
   let body: unknown;
 
   try {
@@ -10,7 +29,7 @@ export async function POST(request: Request) {
   } catch {
     return NextResponse.json(
       { error: "Request body must be valid JSON." },
-      { status: 400 },
+      { headers: rateLimitHeaders, status: 400 },
     );
   }
 
@@ -24,10 +43,10 @@ export async function POST(request: Request) {
           message: issue.message,
         })),
       },
-      { status: 400 },
+      { headers: rateLimitHeaders, status: 400 },
     );
   }
 
   const result = await runTutorProvider(parsed.data);
-  return NextResponse.json(result);
+  return NextResponse.json(result, { headers: rateLimitHeaders });
 }

--- a/app/api/tutor/turn/route.ts
+++ b/app/api/tutor/turn/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { tutorTurnRequestSchema } from "@/lib/domain";
+import { runTutorProvider } from "@/lib/tutor/provider";
+
+export async function POST(request: Request) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Request body must be valid JSON." },
+      { status: 400 },
+    );
+  }
+
+  const parsed = tutorTurnRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: "Invalid tutor turn request.",
+        issues: parsed.error.issues.map((issue) => ({
+          path: issue.path.join("."),
+          message: issue.message,
+        })),
+      },
+      { status: 400 },
+    );
+  }
+
+  const result = await runTutorProvider(parsed.data);
+  return NextResponse.json(result);
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -10,6 +10,8 @@
   --jade-soft: #d7f2ed;
   --amber: #b45309;
   --amber-soft: #f7e3c4;
+  --sky: #2563eb;
+  --sky-soft: #dbeafe;
   --rose: #be123c;
   --rose-soft: #f8d7dd;
   --steel: #334155;
@@ -131,6 +133,12 @@ button:disabled {
   background: var(--amber-soft);
   border-color: rgba(180, 83, 9, 0.3);
   color: #8a3f07;
+}
+
+.status-pill.info {
+  background: var(--sky-soft);
+  border-color: rgba(37, 99, 235, 0.24);
+  color: #1d4ed8;
 }
 
 .workspace {

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,526 @@
+:root {
+  --bg: #f8f4ed;
+  --surface: #fffdf8;
+  --surface-strong: #ffffff;
+  --ink: #17202a;
+  --muted: #68737d;
+  --line: #d9d2c7;
+  --line-strong: #b9aa98;
+  --jade: #0f766e;
+  --jade-soft: #d7f2ed;
+  --amber: #b45309;
+  --amber-soft: #f7e3c4;
+  --rose: #be123c;
+  --rose-soft: #f8d7dd;
+  --steel: #334155;
+  --shadow: 0 18px 50px rgba(23, 32, 42, 0.08);
+  --radius: 8px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  background:
+    linear-gradient(180deg, rgba(255, 253, 248, 0.92), rgba(248, 244, 237, 1)),
+    radial-gradient(circle at 20% 0%, rgba(15, 118, 110, 0.12), transparent 32rem);
+  color: var(--ink);
+  font-family:
+    "Avenir Next",
+    "Segoe UI",
+    "Helvetica Neue",
+    sans-serif;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+.app-shell {
+  min-height: 100vh;
+  padding: 18px;
+}
+
+.top-bar {
+  align-items: center;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  margin: 0 auto 14px;
+  max-width: 1540px;
+}
+
+.brand {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  min-width: 0;
+}
+
+.brand-mark {
+  align-items: center;
+  background: var(--ink);
+  border-radius: var(--radius);
+  color: var(--surface);
+  display: inline-flex;
+  height: 38px;
+  justify-content: center;
+  width: 38px;
+}
+
+.brand h1 {
+  font-size: 1.25rem;
+  line-height: 1.1;
+  margin: 0;
+}
+
+.brand p {
+  color: var(--muted);
+  font-size: 0.86rem;
+  margin: 3px 0 0;
+}
+
+.status-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.status-pill {
+  align-items: center;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--steel);
+  display: inline-flex;
+  font-size: 0.82rem;
+  gap: 7px;
+  min-height: 34px;
+  padding: 7px 10px;
+  white-space: nowrap;
+}
+
+.status-pill.good {
+  background: var(--jade-soft);
+  border-color: rgba(15, 118, 110, 0.28);
+  color: #115e59;
+}
+
+.status-pill.warn {
+  background: var(--amber-soft);
+  border-color: rgba(180, 83, 9, 0.3);
+  color: #8a3f07;
+}
+
+.workspace {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(280px, 340px) minmax(0, 1fr) minmax(280px, 360px);
+  margin: 0 auto;
+  max-width: 1540px;
+}
+
+.panel {
+  background: rgba(255, 253, 248, 0.9);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  min-width: 0;
+}
+
+.panel-header {
+  align-items: flex-start;
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  gap: 10px;
+  justify-content: space-between;
+  padding: 14px;
+}
+
+.panel-header h2,
+.panel-header h3 {
+  font-size: 0.98rem;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.panel-header p {
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.4;
+  margin: 5px 0 0;
+}
+
+.panel-body {
+  padding: 14px;
+}
+
+.scenario-form {
+  display: grid;
+  gap: 13px;
+}
+
+.field {
+  display: grid;
+  gap: 6px;
+}
+
+.field label {
+  color: var(--steel);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.field input,
+.field textarea,
+.field select {
+  background: var(--surface-strong);
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  color: var(--ink);
+  min-height: 40px;
+  padding: 9px 10px;
+  width: 100%;
+}
+
+.field textarea {
+  line-height: 1.45;
+  min-height: 80px;
+  resize: vertical;
+}
+
+.field-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 1fr 1fr;
+}
+
+.role-grid {
+  grid-template-columns: 1fr;
+}
+
+.segmented {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  display: grid;
+  gap: 4px;
+  grid-template-columns: repeat(3, 1fr);
+  padding: 4px;
+}
+
+.segmented button {
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: var(--muted);
+  min-height: 34px;
+  padding: 7px 5px;
+}
+
+.segmented button.active {
+  background: var(--ink);
+  color: var(--surface);
+}
+
+.briefing {
+  background: var(--surface);
+  border-bottom: 1px solid var(--line);
+  display: grid;
+  gap: 8px;
+  padding: 14px 16px;
+}
+
+.briefing h2 {
+  font-size: 1.06rem;
+  margin: 0;
+}
+
+.briefing p {
+  color: var(--steel);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.conversation-panel {
+  display: grid;
+  grid-template-rows: auto minmax(420px, 1fr) auto;
+  max-height: calc(100vh - 90px);
+}
+
+.message-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow: auto;
+  padding: 14px;
+}
+
+.message-card {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  max-width: 82%;
+  padding: 12px;
+}
+
+.message-card.partner {
+  align-self: flex-start;
+  background: var(--surface-strong);
+}
+
+.message-card.user {
+  align-self: flex-end;
+  background: var(--jade-soft);
+  border-color: rgba(15, 118, 110, 0.24);
+}
+
+.message-card.coach {
+  align-self: center;
+  background: var(--amber-soft);
+  border-color: rgba(180, 83, 9, 0.24);
+  max-width: 92%;
+}
+
+.message-meta {
+  align-items: center;
+  color: var(--muted);
+  display: flex;
+  font-size: 0.76rem;
+  font-weight: 700;
+  gap: 7px;
+  justify-content: space-between;
+  margin-bottom: 7px;
+  text-transform: uppercase;
+}
+
+.message-card p {
+  line-height: 1.5;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.composer {
+  background: var(--surface);
+  border-top: 1px solid var(--line);
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
+.transcript-preview {
+  color: var(--muted);
+  font-size: 0.86rem;
+  min-height: 20px;
+}
+
+.composer-row {
+  align-items: end;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+}
+
+.icon-button,
+.primary-button,
+.secondary-button {
+  align-items: center;
+  border-radius: 7px;
+  display: inline-flex;
+  font-weight: 700;
+  gap: 8px;
+  justify-content: center;
+  min-height: 42px;
+  padding: 9px 12px;
+  white-space: nowrap;
+}
+
+.icon-button {
+  aspect-ratio: 1;
+  background: var(--surface-strong);
+  border: 1px solid var(--line);
+  color: var(--ink);
+  padding: 0;
+  width: 42px;
+}
+
+.icon-button.active {
+  background: var(--jade);
+  border-color: var(--jade);
+  color: #ffffff;
+}
+
+.primary-button {
+  background: var(--ink);
+  border: 1px solid var(--ink);
+  color: #ffffff;
+}
+
+.secondary-button {
+  background: var(--surface-strong);
+  border: 1px solid var(--line);
+  color: var(--ink);
+}
+
+.composer textarea {
+  background: var(--surface-strong);
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  line-height: 1.45;
+  max-height: 160px;
+  min-height: 42px;
+  padding: 10px 11px;
+  resize: vertical;
+  width: 100%;
+}
+
+.coach-stack {
+  display: grid;
+  gap: 12px;
+}
+
+.metric-grid {
+  display: grid;
+  gap: 9px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.metric {
+  background: var(--surface-strong);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 10px;
+}
+
+.metric span {
+  color: var(--muted);
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.metric strong {
+  display: block;
+  font-size: 1.25rem;
+  margin-top: 4px;
+}
+
+.coach-card,
+.phrase-card {
+  background: var(--surface-strong);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 12px;
+}
+
+.coach-card h4,
+.phrase-card h4 {
+  font-size: 0.88rem;
+  margin: 0 0 7px;
+}
+
+.coach-card p,
+.phrase-card p {
+  color: var(--steel);
+  line-height: 1.45;
+  margin: 0;
+}
+
+.phrase-list {
+  display: grid;
+  gap: 8px;
+}
+
+.empty-state {
+  align-items: center;
+  color: var(--muted);
+  display: grid;
+  min-height: 180px;
+  padding: 24px;
+  place-items: center;
+  text-align: center;
+}
+
+.warning-text {
+  color: var(--amber);
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+@media (max-width: 1180px) {
+  .workspace {
+    grid-template-columns: minmax(270px, 320px) minmax(0, 1fr);
+  }
+
+  .coach-panel {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 820px) {
+  .app-shell {
+    padding: 10px;
+  }
+
+  .top-bar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .status-row {
+    justify-content: flex-start;
+  }
+
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .conversation-panel {
+    max-height: none;
+  }
+
+  .message-list {
+    min-height: 360px;
+  }
+
+  .message-card {
+    max-width: 94%;
+  }
+
+  .composer-row {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .composer-row .primary-button {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
+
+  .field-grid,
+  .metric-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata, Viewport } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Parrot-AI",
+  description: "Conversation-first language learning practice.",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import { ParrotApp } from "@/components/parrot-app";
+
+export default function Home() {
+  return <ParrotApp />;
+}

--- a/components/parrot-app.tsx
+++ b/components/parrot-app.tsx
@@ -45,6 +45,7 @@ type SavedState = {
   phraseBank: string[];
   lastFeedback: CoachFeedback | null;
   lastScore: SessionScore | null;
+  lastCulturalNote: string | null;
 };
 
 const storageKey = "parrot-ai-v2-session";
@@ -55,7 +56,44 @@ const savedStateSchema = z.object({
   phraseBank: z.array(z.string().min(1).max(180)).max(12).optional(),
   lastFeedback: coachFeedbackSchema.nullable().optional(),
   lastScore: sessionScoreSchema.nullable().optional(),
+  lastCulturalNote: z.string().min(1).max(500).nullable().optional(),
 });
+
+function formatTutorStatus(status: ProviderStatus | null): string {
+  if (!status) {
+    return "Tutor: checking";
+  }
+  if (status.provider === "ollama") {
+    return `Tutor: Ollama${status.ollamaModel ? ` (${status.ollamaModel})` : ""}`;
+  }
+  if (status.provider === "fallback") {
+    return "Tutor: demo";
+  }
+  return "Tutor: unavailable";
+}
+
+function tutorStatusTitle(status: ProviderStatus | null): string {
+  if (!status) {
+    return "Checking which tutor provider is active.";
+  }
+  if (status.provider === "ollama") {
+    return "Using the configured local Ollama chat model.";
+  }
+  if (status.provider === "fallback") {
+    return "Using the built-in demo tutor. No paid AI provider or local chat model is configured.";
+  }
+  return "Tutor provider status could not be checked.";
+}
+
+function speechStatusText(speech: ReturnType<typeof useBrowserSpeech>): string {
+  if (speech.isRecognitionSupported) {
+    return "Mic: browser";
+  }
+  if (speech.isSynthesisSupported) {
+    return "Audio: playback";
+  }
+  return "Voice: typed only";
+}
 
 export function ParrotApp() {
   const [config, setConfig] = useState<ScenarioConfig>(defaultScenarioConfig);
@@ -64,6 +102,7 @@ export function ParrotApp() {
   const [isSending, setIsSending] = useState(false);
   const [lastFeedback, setLastFeedback] = useState<CoachFeedback | null>(null);
   const [lastScore, setLastScore] = useState<SessionScore | null>(null);
+  const [lastCulturalNote, setLastCulturalNote] = useState<string | null>(null);
   const [phraseBank, setPhraseBank] = useState<string[]>([]);
   const [providerStatus, setProviderStatus] = useState<ProviderStatus | null>(null);
   const [warning, setWarning] = useState<string | null>(null);
@@ -96,6 +135,9 @@ export function ParrotApp() {
       if (saved.lastScore) {
         setLastScore(saved.lastScore);
       }
+      if (saved.lastCulturalNote) {
+        setLastCulturalNote(saved.lastCulturalNote);
+      }
     } catch {
       window.localStorage.removeItem(storageKey);
     }
@@ -115,9 +157,10 @@ export function ParrotApp() {
       phraseBank,
       lastFeedback,
       lastScore,
+      lastCulturalNote,
     };
     window.localStorage.setItem(storageKey, JSON.stringify(state));
-  }, [config, lastFeedback, lastScore, messages, phraseBank]);
+  }, [config, lastCulturalNote, lastFeedback, lastScore, messages, phraseBank]);
 
   const handleFinalTranscript = useCallback((text: string) => {
     setDraft((current) => `${current}${current ? " " : ""}${text}`.trim());
@@ -162,6 +205,7 @@ export function ParrotApp() {
       setMessages([...nextMessages, partnerMessage, coachMessage]);
       setLastFeedback(result.coachFeedback);
       setLastScore(result.sessionScore);
+      setLastCulturalNote(result.culturalNote);
       setPhraseBank((current) =>
         Array.from(new Set([...result.phraseBankAdditions, ...current])).slice(0, 12),
       );
@@ -184,6 +228,7 @@ export function ParrotApp() {
     setDraft("");
     setLastFeedback(null);
     setLastScore(null);
+    setLastCulturalNote(null);
     setPhraseBank([]);
     setWarning(null);
   }
@@ -201,17 +246,21 @@ export function ParrotApp() {
           </div>
         </div>
         <div className="status-row" aria-label="System status">
-          <span className={`status-pill ${providerStatus?.provider === "fallback" ? "warn" : "good"}`}>
+          <span
+            className={`status-pill ${providerStatus?.provider === "fallback" ? "info" : "good"}`}
+            title={tutorStatusTitle(providerStatus)}
+          >
             <Bot size={15} />
-            {providerStatus
-              ? `AI: ${providerStatus.provider}${providerStatus.ollamaModel ? ` (${providerStatus.ollamaModel})` : ""}`
-              : "AI: checking"}
+            {formatTutorStatus(providerStatus)}
           </span>
-          <span className={`status-pill ${speech.isRecognitionSupported ? "good" : "warn"}`}>
+          <span
+            className={`status-pill ${speech.isRecognitionSupported ? "good" : "warn"}`}
+            title="Speech uses this browser's built-in speech APIs when available. Typed input always works."
+          >
             {speech.isRecognitionSupported ? <Mic size={15} /> : <MicOff size={15} />}
-            {speech.isRecognitionSupported ? "Speech ready" : "Typed mode"}
+            {speechStatusText(speech)}
           </span>
-          <button className="secondary-button" type="button" onClick={resetSession}>
+          <button className="secondary-button" type="button" onClick={resetSession} title="Clear this practice session">
             <RefreshCw size={16} />
             Reset
           </button>
@@ -232,6 +281,7 @@ export function ParrotApp() {
           onSend={sendTurn}
         />
         <LearningCoach
+          culturalNote={lastCulturalNote}
           feedback={lastFeedback}
           phraseBank={phraseBank}
           score={lastScore}
@@ -492,11 +542,13 @@ function ConversationWorkspace({
 }
 
 function LearningCoach({
+  culturalNote,
   feedback,
   phraseBank,
   score,
   warning,
 }: {
+  culturalNote: string | null;
   feedback: CoachFeedback | null;
   phraseBank: string[];
   score: SessionScore | null;
@@ -522,6 +574,11 @@ function LearningCoach({
           <div className="coach-card">
             <h4>Repair</h4>
             <p>{feedback?.correction ?? "A correction will appear after your first response."}</p>
+          </div>
+
+          <div className="coach-card">
+            <h4>Culture note</h4>
+            <p>{culturalNote ?? "A cultural note will appear after your first response."}</p>
           </div>
 
           <div className="coach-card">

--- a/components/parrot-app.tsx
+++ b/components/parrot-app.tsx
@@ -1,0 +1,562 @@
+"use client";
+
+import {
+  Bot,
+  CheckCircle2,
+  Languages,
+  Mic,
+  MicOff,
+  RefreshCw,
+  Send,
+  Square,
+  Volume2,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { z } from "zod";
+import {
+  buildBriefing,
+  coachFeedbackSchema,
+  createMessage,
+  defaultScenarioConfig,
+  languageOptions,
+  messageSchema,
+  scenarioConfigSchema,
+  sessionScoreSchema,
+  type CoachFeedback,
+  type ConversationMessage,
+  type Intensity,
+  type PracticeMode,
+  type Proficiency,
+  type ScenarioConfig,
+  type SessionScore,
+  type TutorTurnResponse,
+} from "@/lib/domain";
+import { useBrowserSpeech } from "@/hooks/use-browser-speech";
+
+type ProviderStatus = {
+  provider: string;
+  ollamaModel: string | null;
+  speech: string;
+};
+
+type SavedState = {
+  config: ScenarioConfig;
+  messages: ConversationMessage[];
+  phraseBank: string[];
+  lastFeedback: CoachFeedback | null;
+  lastScore: SessionScore | null;
+};
+
+const storageKey = "parrot-ai-v2-session";
+
+const savedStateSchema = z.object({
+  config: scenarioConfigSchema.optional(),
+  messages: z.array(messageSchema).max(18).optional(),
+  phraseBank: z.array(z.string().min(1).max(180)).max(12).optional(),
+  lastFeedback: coachFeedbackSchema.nullable().optional(),
+  lastScore: sessionScoreSchema.nullable().optional(),
+});
+
+export function ParrotApp() {
+  const [config, setConfig] = useState<ScenarioConfig>(defaultScenarioConfig);
+  const [messages, setMessages] = useState<ConversationMessage[]>([]);
+  const [draft, setDraft] = useState("");
+  const [isSending, setIsSending] = useState(false);
+  const [lastFeedback, setLastFeedback] = useState<CoachFeedback | null>(null);
+  const [lastScore, setLastScore] = useState<SessionScore | null>(null);
+  const [phraseBank, setPhraseBank] = useState<string[]>([]);
+  const [providerStatus, setProviderStatus] = useState<ProviderStatus | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      if (!raw) {
+        return;
+      }
+      const parsed = savedStateSchema.safeParse(JSON.parse(raw));
+      if (!parsed.success) {
+        window.localStorage.removeItem(storageKey);
+        return;
+      }
+
+      const saved = parsed.data;
+      if (saved.config) {
+        setConfig(saved.config);
+      }
+      if (saved.messages) {
+        setMessages(saved.messages);
+      }
+      if (saved.phraseBank) {
+        setPhraseBank(saved.phraseBank);
+      }
+      if (saved.lastFeedback) {
+        setLastFeedback(saved.lastFeedback);
+      }
+      if (saved.lastScore) {
+        setLastScore(saved.lastScore);
+      }
+    } catch {
+      window.localStorage.removeItem(storageKey);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/tutor/status")
+      .then((response) => response.json())
+      .then((status: ProviderStatus) => setProviderStatus(status))
+      .catch(() => setProviderStatus({ provider: "unknown", ollamaModel: null, speech: "browser" }));
+  }, []);
+
+  useEffect(() => {
+    const state: SavedState = {
+      config,
+      messages,
+      phraseBank,
+      lastFeedback,
+      lastScore,
+    };
+    window.localStorage.setItem(storageKey, JSON.stringify(state));
+  }, [config, lastFeedback, lastScore, messages, phraseBank]);
+
+  const handleFinalTranscript = useCallback((text: string) => {
+    setDraft((current) => `${current}${current ? " " : ""}${text}`.trim());
+  }, []);
+
+  const speech = useBrowserSpeech(handleFinalTranscript);
+  const briefing = useMemo(() => buildBriefing(config), [config]);
+
+  async function sendTurn() {
+    const userInput = draft.trim();
+    if (!userInput || isSending) {
+      return;
+    }
+
+    setIsSending(true);
+    setWarning(null);
+    const userMessage = createMessage("user", userInput);
+    const nextMessages = [...messages, userMessage];
+    setMessages(nextMessages);
+    setDraft("");
+
+    try {
+      const response = await fetch("/api/tutor/turn", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          config,
+          messages,
+          userInput,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Tutor request failed with ${response.status}`);
+      }
+
+      const result = (await response.json()) as TutorTurnResponse;
+      const partnerMessage = createMessage("partner", result.partnerMessage);
+      const coachMessage = createMessage("coach", result.coachFeedback.summary);
+      setMessages([...nextMessages, partnerMessage, coachMessage]);
+      setLastFeedback(result.coachFeedback);
+      setLastScore(result.sessionScore);
+      setPhraseBank((current) =>
+        Array.from(new Set([...result.phraseBankAdditions, ...current])).slice(0, 12),
+      );
+      setWarning(result.warning ?? null);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Tutor request failed.";
+      setWarning(message);
+      setMessages([
+        ...nextMessages,
+        createMessage("coach", "I could not reach the tutor service. Try again or keep practicing with typed notes."),
+      ]);
+    } finally {
+      setIsSending(false);
+    }
+  }
+
+  function resetSession() {
+    speech.cancelSpeech();
+    setMessages([]);
+    setDraft("");
+    setLastFeedback(null);
+    setLastScore(null);
+    setPhraseBank([]);
+    setWarning(null);
+  }
+
+  return (
+    <main className="app-shell">
+      <header className="top-bar">
+        <div className="brand">
+          <span className="brand-mark" aria-hidden="true">
+            <Languages size={22} />
+          </span>
+          <div>
+            <h1>Parrot-AI</h1>
+            <p>{config.language} practice with cultural context</p>
+          </div>
+        </div>
+        <div className="status-row" aria-label="System status">
+          <span className={`status-pill ${providerStatus?.provider === "fallback" ? "warn" : "good"}`}>
+            <Bot size={15} />
+            {providerStatus
+              ? `AI: ${providerStatus.provider}${providerStatus.ollamaModel ? ` (${providerStatus.ollamaModel})` : ""}`
+              : "AI: checking"}
+          </span>
+          <span className={`status-pill ${speech.isRecognitionSupported ? "good" : "warn"}`}>
+            {speech.isRecognitionSupported ? <Mic size={15} /> : <MicOff size={15} />}
+            {speech.isRecognitionSupported ? "Speech ready" : "Typed mode"}
+          </span>
+          <button className="secondary-button" type="button" onClick={resetSession}>
+            <RefreshCw size={16} />
+            Reset
+          </button>
+        </div>
+      </header>
+
+      <section className="workspace" aria-label="Language practice workspace">
+        <ScenarioStudio config={config} onChange={setConfig} />
+        <ConversationWorkspace
+          briefing={briefing}
+          config={config}
+          draft={draft}
+          isSending={isSending}
+          messages={messages}
+          speech={speech}
+          warning={warning ?? speech.error}
+          onDraftChange={setDraft}
+          onSend={sendTurn}
+        />
+        <LearningCoach
+          feedback={lastFeedback}
+          phraseBank={phraseBank}
+          score={lastScore}
+          warning={warning}
+        />
+      </section>
+    </main>
+  );
+}
+
+function ScenarioStudio({
+  config,
+  onChange,
+}: {
+  config: ScenarioConfig;
+  onChange: (config: ScenarioConfig) => void;
+}) {
+  const update = <K extends keyof ScenarioConfig>(key: K, value: ScenarioConfig[K]) => {
+    onChange({ ...config, [key]: value });
+  };
+
+  return (
+    <aside className="panel">
+      <div className="panel-header">
+        <div>
+          <h2>Scenario Studio</h2>
+          <p>{config.userRole} with {config.partnerRole}</p>
+        </div>
+      </div>
+      <div className="panel-body">
+        <div className="scenario-form">
+          <div className="field-grid">
+            <div className="field">
+              <label htmlFor="language">Target language</label>
+              <select
+                id="language"
+                value={config.language}
+                onChange={(event) => update("language", event.target.value as ScenarioConfig["language"])}
+              >
+                {languageOptions.map((language) => (
+                  <option key={language} value={language}>
+                    {language}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="field">
+              <label htmlFor="nativeLanguage">Feedback language</label>
+              <select
+                id="nativeLanguage"
+                value={config.nativeLanguage}
+                onChange={(event) =>
+                  update("nativeLanguage", event.target.value as ScenarioConfig["nativeLanguage"])
+                }
+              >
+                {languageOptions.map((language) => (
+                  <option key={language} value={language}>
+                    {language}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="field">
+            <label>Proficiency</label>
+            <div className="segmented" role="group" aria-label="Proficiency">
+              {(["Beginner", "Intermediate", "Advanced"] as Proficiency[]).map((level) => (
+                <button
+                  className={config.proficiency === level ? "active" : ""}
+                  key={level}
+                  type="button"
+                  onClick={() => update("proficiency", level)}
+                >
+                  {level}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="field-grid">
+            <div className="field">
+              <label htmlFor="mode">Mode</label>
+              <select
+                id="mode"
+                value={config.mode}
+                onChange={(event) => update("mode", event.target.value as PracticeMode)}
+              >
+                <option>Conversation</option>
+                <option>Debate</option>
+              </select>
+            </div>
+            <div className="field">
+              <label htmlFor="intensity">Intensity</label>
+              <select
+                id="intensity"
+                value={config.intensity}
+                onChange={(event) => update("intensity", event.target.value as Intensity)}
+              >
+                <option>Gentle</option>
+                <option>Focused</option>
+                <option>Stretch</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="field">
+            <label htmlFor="scenario">Situation</label>
+            <textarea
+              id="scenario"
+              value={config.scenario}
+              onChange={(event) => update("scenario", event.target.value)}
+            />
+          </div>
+
+          <div className="field-grid role-grid">
+            <div className="field">
+              <label htmlFor="userRole">Your role</label>
+              <input
+                id="userRole"
+                value={config.userRole}
+                onChange={(event) => update("userRole", event.target.value)}
+              />
+            </div>
+            <div className="field">
+              <label htmlFor="partnerRole">Counterpart</label>
+              <input
+                id="partnerRole"
+                value={config.partnerRole}
+                onChange={(event) => update("partnerRole", event.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="field">
+            <label htmlFor="goal">Conversation goal</label>
+            <textarea
+              id="goal"
+              value={config.goal}
+              onChange={(event) => update("goal", event.target.value)}
+            />
+          </div>
+
+          <div className="field">
+            <label htmlFor="culturalFocus">Cultural focus</label>
+            <textarea
+              id="culturalFocus"
+              value={config.culturalFocus}
+              onChange={(event) => update("culturalFocus", event.target.value)}
+            />
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function ConversationWorkspace({
+  briefing,
+  config,
+  draft,
+  isSending,
+  messages,
+  speech,
+  warning,
+  onDraftChange,
+  onSend,
+}: {
+  briefing: string;
+  config: ScenarioConfig;
+  draft: string;
+  isSending: boolean;
+  messages: ConversationMessage[];
+  speech: ReturnType<typeof useBrowserSpeech>;
+  warning: string | null;
+  onDraftChange: (value: string) => void;
+  onSend: () => void;
+}) {
+  const lastPartnerMessage = [...messages].reverse().find((message) => message.speaker === "partner");
+
+  return (
+    <section className="panel conversation-panel">
+      <div className="briefing">
+        <h2>{config.partnerRole} in {config.language}</h2>
+        <p>{briefing}</p>
+      </div>
+
+      <div aria-label="Conversation messages" className="message-list" aria-live="polite">
+        {messages.length === 0 ? (
+          <div className="empty-state">
+            <p>Start with the first thing you would actually say in this situation.</p>
+          </div>
+        ) : (
+          messages.map((message) => (
+            <article className={`message-card ${message.speaker}`} key={message.id}>
+              <div className="message-meta">
+                <span>{message.speaker === "user" ? config.userRole : message.speaker === "partner" ? config.partnerRole : "Coach"}</span>
+                {message.speaker === "partner" ? (
+                  <button
+                    aria-label="Replay partner message"
+                    className="icon-button"
+                    title="Replay partner message"
+                    type="button"
+                    onClick={() => speech.speak(message.content, config.language)}
+                    disabled={!speech.isSynthesisSupported}
+                  >
+                    <Volume2 size={16} />
+                  </button>
+                ) : null}
+              </div>
+              <p>{message.content}</p>
+            </article>
+          ))
+        )}
+      </div>
+
+      <div className="composer">
+        {warning ? <div className="warning-text">{warning}</div> : null}
+        <div className="transcript-preview">
+          {speech.isListening
+            ? speech.interimTranscript || "Listening..."
+            : lastPartnerMessage
+              ? `Respond to: ${lastPartnerMessage.content.slice(0, 110)}`
+              : "Your first turn sets the tone."}
+        </div>
+        <div className="composer-row">
+          <button
+            aria-label={speech.isListening ? "Stop listening" : "Start listening"}
+            className={`icon-button ${speech.isListening ? "active" : ""}`}
+            title={speech.isListening ? "Stop listening" : "Start listening"}
+            type="button"
+            disabled={!speech.isRecognitionSupported}
+            onClick={() =>
+              speech.isListening ? speech.stopListening() : speech.startListening(config.language)
+            }
+          >
+            {speech.isListening ? <Square size={17} /> : <Mic size={17} />}
+          </button>
+          <textarea
+            aria-label="Your response"
+            value={draft}
+            placeholder="Type your response if speech is unavailable."
+            onChange={(event) => onDraftChange(event.target.value)}
+            onKeyDown={(event) => {
+              if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+                void onSend();
+              }
+            }}
+          />
+          <button className="primary-button" type="button" disabled={isSending || !draft.trim()} onClick={onSend}>
+            {isSending ? <RefreshCw size={16} /> : <Send size={16} />}
+            {isSending ? "Thinking" : "Send"}
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function LearningCoach({
+  feedback,
+  phraseBank,
+  score,
+  warning,
+}: {
+  feedback: CoachFeedback | null;
+  phraseBank: string[];
+  score: SessionScore | null;
+  warning: string | null;
+}) {
+  return (
+    <aside className="panel coach-panel">
+      <div className="panel-header">
+        <div>
+          <h3>Learning Coach</h3>
+          <p>{feedback ? feedback.encouragement : "Waiting for your first turn"}</p>
+        </div>
+        <CheckCircle2 size={19} color="var(--jade)" />
+      </div>
+      <div className="panel-body">
+        <div className="coach-stack">
+          <div className="metric-grid">
+            <Metric label="Clarity" value={score?.clarity ?? 0} />
+            <Metric label="Culture" value={score?.culturalFit ?? 0} />
+            <Metric label="Momentum" value={score?.momentum ?? 0} />
+          </div>
+
+          <div className="coach-card">
+            <h4>Repair</h4>
+            <p>{feedback?.correction ?? "A correction will appear after your first response."}</p>
+          </div>
+
+          <div className="coach-card">
+            <h4>Try this</h4>
+            <p>{feedback?.repairedPhrase ?? "Send a turn to build a phrase you can reuse."}</p>
+          </div>
+
+          {warning ? (
+            <div className="coach-card">
+              <h4>Provider note</h4>
+              <p>{warning}</p>
+            </div>
+          ) : null}
+
+          <section aria-label="Phrase bank" className="phrase-card">
+            <h4>Phrase bank</h4>
+            <div className="phrase-list">
+              {phraseBank.length === 0 ? (
+                <p>Reusable phrases will collect here.</p>
+              ) : (
+                phraseBank.map((phrase) => <p key={phrase}>{phrase}</p>)
+              )}
+            </div>
+          </section>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="metric">
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}

--- a/components/parrot-app.tsx
+++ b/components/parrot-app.tsx
@@ -22,6 +22,7 @@ import {
   messageSchema,
   scenarioConfigSchema,
   sessionScoreSchema,
+  tutorTurnResponseSchema,
   type CoachFeedback,
   type ConversationMessage,
   type Intensity,
@@ -199,7 +200,13 @@ export function ParrotApp() {
         throw new Error(`Tutor request failed with ${response.status}`);
       }
 
-      const result = (await response.json()) as TutorTurnResponse;
+      const responseBody = await response.json();
+      const parsedResult = tutorTurnResponseSchema.safeParse(responseBody);
+      if (!parsedResult.success) {
+        throw new Error("Tutor service returned an invalid response.");
+      }
+
+      const result: TutorTurnResponse = parsedResult.data;
       const partnerMessage = createMessage("partner", result.partnerMessage);
       const coachMessage = createMessage("coach", result.coachFeedback.summary);
       setMessages([...nextMessages, partnerMessage, coachMessage]);

--- a/docs/overhaul/engineering-plan.md
+++ b/docs/overhaul/engineering-plan.md
@@ -1,0 +1,296 @@
+# Parrot-AI engineering plan
+
+Date: 2026-06-07
+Branch: overhaul/conversation-learning-app
+
+## Recommended stack
+
+- Next.js 16, React 19, TypeScript.
+- App Router with server route handlers for AI provider calls.
+- Plain CSS modules/global CSS for tight design control.
+- Browser Web Speech API for the zero-cost speech baseline.
+- OpenAI-compatible provider interface:
+  - `fallback` deterministic provider for tests/demo.
+  - `ollama` provider for local models.
+  - future `openai`, `deepgram`, `assemblyai`, `elevenlabs` adapters.
+- Vitest for unit/integration tests.
+- Playwright for browser-level E2E.
+
+Why Next.js:
+- Single production app instead of Streamlit + FastAPI split.
+- Good TypeScript support.
+- Server routes can hide API keys.
+- Easy Vercel deployment later.
+- Current local package ecosystem supports latest Next.js, React, Vitest, and
+  Playwright.
+
+## Architecture
+
+```
+Browser
+  |
+  | speech recognition / speech synthesis
+  v
+Next.js app
+  |
+  +-- Scenario Studio UI
+  +-- Conversation Workspace UI
+  +-- Learning Coach UI
+  +-- Local persistence
+  |
+  v
+Next.js API route /api/tutor/turn
+  |
+  +-- request validation
+  +-- prompt construction
+  +-- provider selection
+  +-- structured response parsing
+  |
+  v
+AI provider adapter
+  |
+  +-- deterministic fallback
+  +-- Ollama OpenAI-compatible local model
+  +-- future cloud providers
+```
+
+## Data model
+
+```
+ScenarioConfig
+  language
+  nativeLanguage
+  proficiency
+  mode
+  scenario
+  userRole
+  partnerRole
+  goal
+  culturalFocus
+  intensity
+
+Message
+  id
+  speaker: user | partner | coach
+  content
+  translation?
+  feedback?
+  createdAt
+
+TurnRequest
+  config
+  messages
+  userInput
+  provider
+
+TurnResponse
+  partnerMessage
+  coachFeedback
+  culturalNote
+  phraseBankAdditions
+  sessionScore
+```
+
+## Provider contract
+
+Provider adapters must return the same structured shape:
+
+```
+{
+  partnerMessage: string,
+  coachFeedback: {
+    summary: string,
+    correction: string,
+    repairedPhrase: string,
+    encouragement: string
+  },
+  culturalNote: string,
+  phraseBankAdditions: string[],
+  sessionScore: {
+    clarity: number,
+    culturalFit: number,
+    momentum: number
+  }
+}
+```
+
+If a provider returns malformed JSON, the route should:
+1. Attempt to extract JSON from text.
+2. Fall back to deterministic response.
+3. Include a provider warning in the response metadata.
+
+## Error and rescue map
+
+| Codepath | What can go wrong | Handling | User sees |
+|---|---|---|---|
+| Browser STT | Unsupported browser | Detect support | Typed fallback |
+| Browser STT | Permission denied | Catch error | Mic permission guidance |
+| Browser TTS | No voices | Detect voices | Text-only/replay disabled |
+| `/api/tutor/turn` | Invalid payload | Zod validation | Clear client error |
+| Provider call | Timeout | Abort/retry/fallback | Fallback response + warning |
+| Provider call | Malformed JSON | Parse recovery/fallback | Session continues |
+| Local storage | Parse error | Reset bad state | Fresh local session |
+| Debrief | No messages | Disable debrief | Prompt to start session |
+
+## Security review
+
+New attack surfaces:
+- Prompt injection through scenario/user messages.
+- User-controlled text rendered in message timeline.
+- Future API keys for providers.
+- Future persisted user data.
+
+Mitigations in first implementation:
+- Treat AI output as plain text only.
+- Never render HTML from provider/user text.
+- Keep provider keys server-side only.
+- Validate all API request bodies with Zod.
+- Limit transcript/message lengths.
+- Use deterministic fallback rather than exposing raw provider failures.
+
+Future production requirements:
+- Auth and per-user scoping.
+- Rate limits for provider-backed endpoints.
+- Abuse detection for prompt injection / unsafe role-play.
+- Provider secret rotation.
+- Content moderation for public/shared scenarios.
+
+## Prompt design
+
+The prompt should separate:
+- System role: language tutor and role-play counterpart.
+- Scenario context.
+- Conversation rules.
+- Output JSON schema.
+- Recent message history.
+- User latest turn.
+
+Important constraints:
+- Keep AI partner message concise.
+- Feedback in native language.
+- Correction must be actionable.
+- Cultural note must be tied to the turn.
+- Phrase bank additions should be reusable.
+
+## Test strategy
+
+Unit:
+- Scenario defaults.
+- Prompt building.
+- Fallback provider.
+- Provider JSON parsing.
+- Local storage reducer/helpers.
+
+Integration:
+- `/api/tutor/turn` valid payload.
+- `/api/tutor/turn` invalid payload.
+- Provider fallback path.
+
+E2E:
+- App renders.
+- User changes scenario fields.
+- User sends typed turn.
+- AI response appears.
+- Feedback appears.
+- Debrief/phrase bank appears.
+- Browser speech unsupported state is non-blocking.
+
+Eval:
+- Prompt output schema adherence.
+- Partner response stays in target language.
+- Feedback is repair-focused.
+- Cultural note is concrete.
+
+## Implementation phases
+
+### Phase 1: Production web foundation
+
+- Add Next.js app in repo root.
+- Keep legacy Streamlit/FastAPI files for history but remove them from active
+  scripts.
+- Implement typed domain models.
+- Implement fallback and Ollama provider adapters.
+- Implement full app UI.
+- Add tests and Playwright.
+
+### Phase 2: Persistence and provider upgrades
+
+- Add Supabase/Postgres schema.
+- Add user auth.
+- Add cloud STT/TTS adapters.
+- Add server-side rate limiting.
+
+### Phase 3: Voice-agent quality
+
+- Add WebSocket streaming.
+- Add VAD/turn detection.
+- Add pronunciation scoring.
+- Add quality eval suite by language and proficiency.
+
+## Rollback
+
+This branch does not modify production deployment yet. Rollback is git revert or
+switching active scripts back to legacy app.
+
+## Deployment path
+
+First deploy target: Vercel.
+
+Implemented env vars for optional providers:
+
+```
+TUTOR_PROVIDER=fallback | ollama
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=qwen3:8b
+```
+
+For production provider integrations later:
+
+```
+OPENAI_API_KEY=
+OPENAI_MODEL=
+DEEPGRAM_API_KEY=
+ASSEMBLYAI_API_KEY=
+ELEVENLABS_API_KEY=
+```
+
+## Existing code leverage
+
+Reuse conceptually:
+- Old role/scenario conversation premise.
+- Old supported languages list.
+- Old local LLM privacy idea.
+
+Do not reuse directly:
+- Streamlit UI.
+- FastAPI global `dual_chatbot` state.
+- gTTS dependency.
+- Existing evaluation script, except as historical benchmark.
+
+## Design review summary
+
+Initial design completeness: 8/10 after this plan.
+
+Remaining gaps:
+- Exact visual mockups not generated by gstack designer.
+- Mobile microphone UX will need real browser QA.
+- Provider error copy needs refinement after implementation.
+
+## CEO review summary
+
+Scope mode: selective expansion.
+
+Accepted now:
+- Full standalone web app.
+- Local-first speech/LLM baseline.
+- Cultural briefing and repair feedback.
+- Tests and browser QA.
+
+Deferred:
+- Cloud paid providers.
+- Auth/database.
+- Real-time duplex voice.
+- Pronunciation scoring.
+
+Rationale: this gives the user a real app to try quickly while preserving the
+long-term architecture.

--- a/docs/overhaul/product-design-spec.md
+++ b/docs/overhaul/product-design-spec.md
@@ -1,0 +1,309 @@
+# Parrot-AI product and design spec
+
+Date: 2026-06-07
+Branch: overhaul/conversation-learning-app
+Mode: gstack office-hours builder mode, auto-decided
+
+## Problem statement
+
+Language learning does not stick when the user only studies words and grammar.
+The product should force application: realistic back-and-forth conversation,
+cultural context, correction, repetition, and reflection.
+
+The app should feel less like a quiz app and more like a private conversation
+gym: the user enters a situation, speaks in the target language, gets pushed to
+repair mistakes, and leaves with a concrete memory of what they can now say.
+
+## Product thesis
+
+Duolingo optimizes for low-friction habit loops. Parrot-AI should optimize for
+high-transfer practice: the user should become more capable in real-world
+conversations after each session.
+
+The core loop:
+
+1. Choose or generate a scenario.
+2. Read a short cultural briefing.
+3. Speak to an AI counterpart.
+4. Get immediate lightweight coaching.
+5. Repair weak turns.
+6. Finish with a debrief, phrase bank, and next drill.
+
+## Premises
+
+1. Conversation is the primary learning object, not a decorative output.
+2. Push-to-talk is acceptable for the first high-quality web version.
+3. Browser speech is good enough for a free beta if the UI detects unsupported
+   browsers and provides typed fallback.
+4. The app must work without paid keys, but paid providers should be pluggable.
+5. Local LLMs should be supported, but not treated as the only production path.
+6. Cultural context has to be generated and shown before the conversation,
+   then reinforced during feedback.
+
+## Approaches considered
+
+### Approach A: Minimal web rewrite
+
+Summary: Replace Streamlit with a standalone React/Next.js app, use browser
+speech, and call the old FastAPI backend.
+
+Effort: M
+Risk: Medium
+
+Pros:
+- Fastest path from current repo.
+- Reuses some existing Python code.
+- Low dependency churn.
+
+Cons:
+- Keeps split app/backend complexity.
+- Existing backend global state is not production-safe.
+- Old prompt model is not rich enough for the desired experience.
+
+### Approach B: Production web foundation (recommended)
+
+Summary: Build a new Next.js app with typed domain models, provider adapters,
+browser speech baseline, deterministic fallback, and room for cloud/local
+providers.
+
+Effort: L
+Risk: Medium
+
+Pros:
+- Removes Streamlit completely from the active path.
+- Keeps one deployable web app for MVP.
+- Makes local and cloud providers swappable.
+- Allows proper UI testing and browser QA.
+
+Cons:
+- Rewrites more code.
+- The first implementation will not include every paid provider.
+- Auth/database still need a second phase.
+
+### Approach C: Full voice-agent backend
+
+Summary: Build real-time STT/TTS/LLM orchestration with WebSockets, turn
+detection, VAD, provider streaming, and persisted user profiles.
+
+Effort: XL
+Risk: High
+
+Pros:
+- Best long-term voice UX.
+- Can support interruptions and natural live conversation.
+- Strongest production voice-agent architecture.
+
+Cons:
+- Too much infrastructure before we know the exact learning loop.
+- Requires paid services or local sidecars to feel good.
+- More failure modes before the product surface is proven.
+
+Recommendation: Approach B. It moves decisively away from Streamlit, ships a
+real app surface, and avoids overcommitting to expensive voice infrastructure
+before the learning loop is tested.
+
+## Experience principles
+
+- Speak first: text input is fallback, not the main experience.
+- Context first: every scenario starts with social/cultural setup.
+- Repair beats scoring: feedback should get the user to try again, not just
+  grade them.
+- Make progress visible: show stronger phrases, corrected turns, and next
+  challenge.
+- Keep the interface calm: language practice is cognitively heavy; avoid noisy
+  decoration and gamified clutter.
+
+## Information architecture
+
+```
+App shell
+  Header
+    Product name
+    Provider/status indicator
+    Session controls
+
+  Main workspace
+    Left rail: Scenario Studio
+      Language
+      Proficiency
+      Scenario
+      Conversation goal
+      Cultural lens
+      Intensity
+
+    Center: Live Conversation
+      Cultural briefing
+      Dialogue timeline
+      Push-to-talk / typed fallback
+      Tutor nudge after each turn
+
+    Right rail: Learning Coach
+      Session objective
+      Active corrections
+      Useful phrases
+      Confidence/progress
+
+  Debrief view
+    What you handled well
+    What to repair
+    Phrase bank
+    Next drills
+```
+
+## Core screens
+
+### Scenario Studio
+
+The user configures:
+- Target language.
+- Native language.
+- Proficiency.
+- Situation.
+- AI counterpart role.
+- User role.
+- Conversation goal.
+- Cultural focus.
+- Challenge level.
+
+Default examples:
+- Spanish, intermediate, asking a pharmacist about allergy medicine.
+- French, beginner, ordering at a bakery without switching to English.
+- German, advanced, negotiating an apartment viewing time.
+- Hindi, intermediate, visiting a family friend and handling politeness.
+
+### Live Conversation
+
+Visible hierarchy:
+1. What situation am I in?
+2. What is my objective?
+3. What did the AI say?
+4. How do I respond?
+5. What should I repair?
+
+The screen must support:
+- Listening state.
+- Speaking state.
+- Thinking state.
+- Error state.
+- Typed fallback.
+- Replay AI voice.
+- "Give me a hint" without ending the attempt.
+- "Repair this turn" after feedback.
+
+### Debrief
+
+The debrief should not be a generic summary. It should produce:
+- Three strongest phrases the user used or should use.
+- Three corrected turns.
+- Cultural notes tied to the scenario.
+- Next scenario recommendation.
+- A small review deck saved locally.
+
+## Interaction state table
+
+| Feature | Loading | Empty | Error | Success | Partial |
+|---|---|---|---|---|---|
+| Provider status | Checking model/provider | Fallback mode | Provider unavailable | Connected | Connected but no speech |
+| Scenario generation | Drafting briefing | Default scenario shown | Use manual defaults | Briefing ready | Some fields missing |
+| Mic capture | Listening pulse | Typed fallback | Browser unsupported | Transcript captured | Interim transcript |
+| AI turn | Thinking indicator | Starter prompt available | Retry/fallback turn | AI message shown | Message without audio |
+| TTS | Preparing voice | Text-only | Voice unavailable | Audio spoken | Voice changed |
+| Feedback | Analyzing turn | No user turn yet | Show simple heuristic | Correction shown | Low confidence feedback |
+| Debrief | Building review | No session yet | Retry summary | Debrief saved | Partial phrase bank |
+
+## User journey
+
+```
+Step | User does | User should feel | Design support
+--- | --- | --- | ---
+1 | Opens app | Oriented, not sold to | Workspace first, no landing page
+2 | Chooses scenario | In control | Compact scenario controls
+3 | Reads briefing | Situated | Clear cultural note before speaking
+4 | Speaks first turn | Challenged but safe | Push-to-talk, typed fallback
+5 | Gets response | In a real exchange | Timeline, replay, concise AI turns
+6 | Gets correction | Coached, not judged | Repair-focused feedback
+7 | Finishes | Progress is concrete | Debrief and saved phrase bank
+```
+
+## AI behavior spec
+
+The AI must:
+- Stay in the selected role.
+- Keep responses appropriate to proficiency.
+- Avoid solving the user's turn for them.
+- Add cultural realism without long lectures.
+- Ask follow-up questions that force a response.
+- Track session objective and escalate difficulty gradually.
+- Provide feedback in the user's native language unless configured otherwise.
+
+The AI must not:
+- Produce long monologues.
+- Translate every line automatically during live practice.
+- Overcorrect every mistake.
+- Switch languages unless the scenario or feedback mode requires it.
+- Pretend the user spoke correctly when transcript is empty or unclear.
+
+## Design direction
+
+Use a calm productivity-app style, not a marketing hero and not a childish game.
+
+Visual constraints:
+- No card grids as the first impression.
+- No purple/blue gradient theme.
+- No emoji-based controls.
+- Use icons for actions.
+- Keep cards for actual repeated content: messages, correction items, phrase
+  bank entries.
+- Dense, readable controls.
+- Text must never overlap controls on mobile or desktop.
+- Use visible labels for form fields.
+
+Palette:
+- Warm white background.
+- Ink text.
+- Jade accent for success/listening.
+- Amber for coaching/repair.
+- Slate for structure.
+
+## Success criteria
+
+For the first production foundation:
+- User can run app without API keys.
+- User can complete a session using text fallback.
+- Browser speech works when supported.
+- User receives cultural briefing, AI turns, feedback, and debrief.
+- Local session state persists.
+- Tests cover core prompt/domain logic and UI flows.
+- Playwright verifies the main route and a complete typed conversation.
+
+For production readiness later:
+- Auth and persisted profiles.
+- Cloud STT/TTS adapters.
+- Pronunciation scoring.
+- LLM quality evals across target languages.
+- Deployment with secrets and monitoring.
+
+## Not in scope for first implementation
+
+- Payment/subscriptions.
+- User auth.
+- Database persistence.
+- Cloud speech API implementation.
+- Full duplex real-time voice agent.
+- Mobile native app.
+- CEFR-certified assessment.
+- True pronunciation scoring.
+
+## Manual tasks expected later
+
+1. Choose which paid provider keys to enable:
+   - Deepgram for STT/TTS.
+   - OpenAI for LLM/TTS/transcription.
+   - ElevenLabs only if premium TTS is required.
+2. Install a local chat model if local mode should be used:
+   - Example: `ollama pull qwen3:8b` or a newer multilingual chat model.
+3. Choose hosting:
+   - Vercel for the Next.js app.
+   - Render/Fly/Railway only if a Python/sidecar service is added.
+4. Choose persistence:
+   - Supabase/Postgres is the most direct next step.

--- a/docs/overhaul/research-voice-llm-stack.md
+++ b/docs/overhaul/research-voice-llm-stack.md
@@ -1,0 +1,260 @@
+# Parrot-AI overhaul research: voice, LLM, and cost stack
+
+Date: 2026-06-07
+Branch: overhaul/conversation-learning-app
+
+## Goal
+
+Build a conversation-first language learning app where the user learns by
+speaking, repairing mistakes, replaying culturally realistic situations, and
+reviewing what they struggled with.
+
+Primary constraint: keep the default experience free or very cheap, but do not
+let cheapness degrade the core loop. The app should support local-first
+providers and cloud upgrades through the same interface.
+
+## Current recommendation
+
+Use a provider-pluggable architecture:
+
+1. Browser/local baseline:
+   - STT: Web Speech API when available.
+   - TTS: SpeechSynthesis when available.
+   - LLM: Ollama OpenAI-compatible adapter when a local chat model is installed.
+   - Fallback: deterministic scripted tutor for demos/tests when no model exists.
+2. Cloud production upgrade:
+   - STT: Deepgram Flux/Nova-3 for low-latency multilingual conversation, or
+     AssemblyAI Universal-Streaming for a cheaper real-time path.
+   - TTS: browser SpeechSynthesis for beta, Deepgram Aura for lower-cost cloud
+     voice, OpenAI gpt-4o-mini-tts for simple developer integration, ElevenLabs
+     only for premium voice quality.
+   - LLM: OpenAI-compatible adapter, with OpenAI/Anthropic/etc. as optional
+     hosted providers and Ollama for local.
+
+This lets us launch a good local beta without keys, then add API keys only where
+quality or browser compatibility requires it.
+
+## Source-backed notes
+
+### Browser speech baseline
+
+MDN describes the Web Speech API as having two parts: SpeechSynthesis for TTS
+and SpeechRecognition for asynchronous speech recognition:
+https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API
+
+Important caveat: MDN says recognition can use a platform service by default or
+local browser recognition if supported. This is free from the app's perspective,
+but not guaranteed to be fully offline or consistent across browsers.
+
+SpeechSynthesis is widely available and can retrieve available device voices:
+https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis
+
+Use this for the first free baseline. Production UI must detect support and
+show a cloud/provider setup path when recognition is unavailable.
+
+### Deepgram
+
+Official pricing page:
+https://deepgram.com/pricing
+
+Relevant facts:
+- Pay-as-you-go has a free credit and no minimums.
+- Flux is positioned for real-time voice agents with turn detection,
+  interruption handling, and low latency.
+- Nova-3 is the recommended high-performing STT model for noisy/multilingual
+  cases.
+- Streaming pay-as-you-go rates listed:
+  - Flux English: about $0.0065/min.
+  - Flux Multilingual: about $0.0078/min.
+  - Nova-3 Monolingual: about $0.0048/min.
+  - Nova-3 Multilingual: about $0.0058/min.
+- Aura TTS listed:
+  - Aura-2: $0.030/1k characters.
+  - Aura-1: $0.015/1k characters.
+
+Product implication: Deepgram is the best first paid STT adapter because it is
+designed for conversational latency and supports turn-taking concerns that this
+app cares about.
+
+### AssemblyAI
+
+Official pricing page:
+https://www.assemblyai.com/pricing/
+
+Relevant facts:
+- Pre-recorded Universal-2: $0.15/hr and supports 99 languages.
+- Universal-3 Pro pre-recorded: $0.21/hr, currently narrower language support.
+- Realtime Universal-Streaming: $0.15/hr.
+- Realtime Universal-3 Pro Streaming: $0.45/hr.
+- Realtime multilingual streaming supports English, Spanish, German, French,
+  Portuguese, and Italian at $0.15/hr.
+
+Product implication: AssemblyAI is attractive for cost, especially English and
+common European languages. Deepgram is still the stronger first paid voice-agent
+fit because of Flux and explicit turn-taking posture.
+
+### OpenAI audio
+
+Official model docs:
+- Transcription: https://developers.openai.com/api/docs/models/gpt-4o-transcribe
+- TTS: https://developers.openai.com/api/docs/models/gpt-4o-mini-tts
+
+Relevant facts:
+- GPT-4o Transcribe model page lists audio input pricing by 1M tokens and
+  compares it with GPT-4o mini Transcribe.
+- GPT-4o mini TTS lists text input and audio output token pricing.
+
+Product implication: OpenAI is useful for simple provider integration because
+the app can use one OpenAI-compatible stack for LLM and audio. It may be less
+cost-transparent for a beginner project than per-hour STT and per-character TTS.
+
+### Google Cloud speech
+
+Official pricing:
+- STT: https://cloud.google.com/speech-to-text/pricing
+- TTS: https://cloud.google.com/text-to-speech/pricing
+
+Relevant facts:
+- Google STT dynamic batch recognition lists $0.003/min for standard models.
+- Standard models include default, command_and_search, latest_short,
+  latest_long, phone_call, video, and chirp.
+- Google Chirp 3 HD TTS lists 1M free characters then $30/1M characters.
+
+Product implication: Google is useful for broad language support and mature
+cloud infrastructure, but the first implementation should avoid Google setup
+complexity unless a target language needs it.
+
+### Azure speech
+
+Official pricing:
+https://azure.microsoft.com/en-us/pricing/details/speech/
+
+Relevant facts:
+- Azure exposes unified speech-to-text, text-to-speech, and translation pricing.
+- TTS billing is per character.
+- Free/container pricing paths exist, but public page pricing is region and
+  account dependent in places.
+
+Product implication: Azure is enterprise-capable and language-rich, but too
+heavy for the first indie rebuild unless deployment is already on Azure.
+
+### Local ASR
+
+whisper.cpp:
+https://github.com/ggml-org/whisper.cpp
+
+Relevant facts:
+- High-performance C/C++ implementation of OpenAI Whisper.
+- Supports Apple Silicon optimizations, Metal, Core ML, CPU-only inference,
+  Vulkan, NVIDIA GPU, and WebAssembly.
+- Model memory ranges from tiny (~273 MB) to large (~3.9 GB).
+
+faster-whisper:
+https://github.com/SYSTRAN/faster-whisper
+
+Relevant facts:
+- Benchmarks show major speedups versus original Whisper, especially with
+  batching and int8 quantization.
+- Best suited for a Python sidecar service rather than browser-only app.
+
+Silero VAD:
+https://github.com/snakers4/silero-vad
+
+Relevant facts:
+- Lightweight voice activity detector.
+- One 30 ms audio chunk can process in less than 1 ms on a single CPU thread.
+- MIT licensed and useful for turn detection.
+
+Product implication: local ASR is good enough for desktop users with modern
+hardware, but browser integration is non-trivial. For the first production web
+foundation, Web Speech API is the local/free path; whisper.cpp/faster-whisper
+becomes a future optional local sidecar.
+
+### Local TTS
+
+Piper:
+https://github.com/rhasspy/piper
+
+Relevant facts:
+- Fast, local neural TTS system.
+- Good CPU/edge candidate.
+
+Product implication: local TTS is viable for an offline sidecar, but browser
+SpeechSynthesis is easier and already cross-device. Piper or Kokoro should be a
+future optional local service, not a first dependency.
+
+### Local LLMs
+
+Ollama:
+- Docs: https://docs.ollama.com/index
+- OpenAI compatibility: https://docs.ollama.com/api/openai-compatibility
+
+Relevant facts:
+- Ollama supports local models such as Gemma, Qwen, DeepSeek, and others.
+- Ollama exposes partial OpenAI API compatibility.
+- Local machine currently has Ollama installed, but only embedding models are
+  installed, not a chat model.
+
+Gemma 3:
+https://ai.google.dev/gemma/docs/core/model_card_3
+
+Relevant facts:
+- Open-weight model family from Google.
+- Multimodal text/image input and text output.
+- 128K context and multilingual support in over 140 languages.
+
+Product implication: local models are good enough for a strong beta if the user
+installs a capable chat model. They may not be reliable enough as the only
+production path for cultural nuance, correction accuracy, and safety. Build the
+app so local is first-class but cloud LLMs can be enabled without UI changes.
+
+## Provider decision matrix
+
+| Layer | Free/local beta | Best first paid path | Premium path | Notes |
+|---|---|---|---|---|
+| STT | Web Speech API | Deepgram Flux/Nova-3 | Google/Azure for specific languages | Browser support is the beta risk. |
+| TTS | SpeechSynthesis | Deepgram Aura or OpenAI mini TTS | ElevenLabs | ElevenLabs should be premium-only due cost. |
+| LLM | Ollama OpenAI-compatible | OpenAI-compatible hosted model | Best frontier model available | Use structured JSON and evals for quality. |
+| Turn detection | Browser push-to-talk | Deepgram Flux / Silero VAD sidecar | Voice-agent API | Push-to-talk is simplest and reliable. |
+| Persistence | localStorage | Supabase/Postgres | Managed Postgres + auth | Start local, design DB schema now. |
+
+## Local model answer
+
+Local models can be good enough for:
+- Scenario generation.
+- Basic role-play.
+- Vocabulary extraction.
+- Simple grammar correction.
+- Private/offline practice.
+
+Local models are risky for:
+- Accurate cultural nuance across many languages.
+- Fine-grained pronunciation coaching.
+- Multi-turn pedagogy that adapts over weeks.
+- Safety and prompt-injection resistance.
+- Consistent structured JSON under small model constraints.
+
+Decision: implement local-first and provider-pluggable. Do not hardcode local as
+the only production path.
+
+## First implementation scope
+
+Build the standalone web app with:
+- Scenario studio.
+- Live conversation practice.
+- Browser mic capture through Web Speech API.
+- Browser TTS through SpeechSynthesis.
+- LLM provider abstraction:
+  - deterministic fallback for tests/demo,
+  - Ollama/OpenAI-compatible endpoint when configured.
+- Cultural briefing before each scenario.
+- Tutor feedback after each user turn.
+- Session debrief with corrections, phrases, and next drills.
+- Local progress persistence.
+
+Defer:
+- User auth and cloud DB.
+- Paid STT/TTS adapters.
+- Pronunciation scoring.
+- Whisper/faster-whisper sidecar.
+- Mobile app packaging.

--- a/docs/overhaul/test-plan.md
+++ b/docs/overhaul/test-plan.md
@@ -1,0 +1,90 @@
+# Parrot-AI overhaul test plan
+
+Date: 2026-06-07
+Branch: overhaul/conversation-learning-app
+
+## Affected pages and routes
+
+- `/` - main language practice workspace.
+- `/api/tutor/turn` - structured tutor/partner response endpoint.
+
+## Critical paths
+
+1. User opens the app.
+2. App shows scenario controls, provider status, conversation workspace, and
+   coach panel.
+3. User edits scenario settings.
+4. User submits a typed response.
+5. API returns a partner message, coaching feedback, cultural note, phrase bank
+   additions, and score.
+6. UI appends the user message and AI response.
+7. Feedback appears in the coach panel.
+8. Phrase bank persists locally.
+9. User can replay AI speech if SpeechSynthesis is available.
+
+## Unit coverage
+
+| Area | Required tests |
+|---|---|
+| Domain defaults | Default scenario config has valid language/proficiency/roles |
+| Prompt builder | Includes scenario, target language, proficiency, recent history |
+| Fallback provider | Produces structured response for empty and non-empty turns |
+| Response parser | Parses JSON, extracts JSON from text, falls back on malformed text |
+| Validation | Rejects missing/too-long fields |
+| Local state | Adds messages, phrase bank, and feedback without mutation bugs |
+
+## Integration coverage
+
+| Route | Case | Expected |
+|---|---|---|
+| `/api/tutor/turn` | Valid payload, fallback provider | 200 structured response |
+| `/api/tutor/turn` | Empty user input | 400 validation error |
+| `/api/tutor/turn` | Provider unavailable | 200 fallback response with warning |
+| `/api/tutor/turn` | Long transcript | 400 validation error |
+
+## E2E coverage
+
+| Flow | Assertions |
+|---|---|
+| App smoke | Main controls and conversation workspace visible |
+| Typed conversation | Send turn, see user message, AI message, coach feedback |
+| Scenario editing | Changing language/scenario updates briefing context |
+| Debrief/phrase bank | Phrase bank item appears after turn |
+| Responsive | Mobile viewport does not overlap controls |
+
+## QA focus
+
+- No text overlap at desktop or mobile widths.
+- Mic unsupported state is clear and does not block typed practice.
+- Buttons have stable dimensions.
+- Provider status is visible.
+- User can practice without reading instructions.
+- AI output is displayed as text, never HTML.
+
+## Eval cases
+
+Initial eval cases for future LLM quality tests:
+
+1. Spanish beginner, restaurant order:
+   - Partner uses Spanish only.
+   - Feedback is short and in English.
+   - Correction is beginner-friendly.
+2. German intermediate, apartment viewing:
+   - Partner asks a follow-up question.
+   - Cultural note mentions formality or punctuality.
+3. Hindi intermediate, family visit:
+   - Feedback handles politeness/register.
+   - Does not over-literalize cultural behavior.
+4. French advanced, work disagreement:
+   - Uses advanced vocabulary.
+   - Feedback focuses on nuance and tone.
+
+## Manual QA after implementation
+
+1. Run `npm run dev`.
+2. Open `http://localhost:3000`.
+3. Complete one typed session.
+4. Try microphone if browser supports speech recognition.
+5. Try replay voice.
+6. Resize to mobile width.
+7. Run Playwright.

--- a/hooks/use-browser-speech.ts
+++ b/hooks/use-browser-speech.ts
@@ -1,0 +1,130 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Language } from "@/lib/domain";
+import { languageCodes } from "@/lib/domain";
+
+type SpeechState = {
+  isRecognitionSupported: boolean;
+  isSynthesisSupported: boolean;
+  isListening: boolean;
+  interimTranscript: string;
+  error: string | null;
+  startListening: (language: Language) => void;
+  stopListening: () => void;
+  speak: (text: string, language: Language) => void;
+  cancelSpeech: () => void;
+};
+
+export function useBrowserSpeech(onFinalTranscript: (text: string) => void): SpeechState {
+  const [isListening, setIsListening] = useState(false);
+  const [interimTranscript, setInterimTranscript] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [speechSupport, setSpeechSupport] = useState({
+    recognition: false,
+    synthesis: false,
+  });
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const recognitionConstructorRef = useRef<SpeechRecognitionConstructor | undefined>(undefined);
+  const finalTranscriptRef = useRef(onFinalTranscript);
+
+  useEffect(() => {
+    finalTranscriptRef.current = onFinalTranscript;
+  }, [onFinalTranscript]);
+
+  useEffect(() => {
+    recognitionConstructorRef.current =
+      window.SpeechRecognition ?? window.webkitSpeechRecognition;
+    setSpeechSupport({
+      recognition: Boolean(recognitionConstructorRef.current),
+      synthesis: "speechSynthesis" in window,
+    });
+  }, []);
+
+  const stopListening = useCallback(() => {
+    recognitionRef.current?.stop();
+    setIsListening(false);
+  }, []);
+
+  const startListening = useCallback(
+    (language: Language) => {
+      const SpeechRecognitionCtor = recognitionConstructorRef.current;
+      if (!SpeechRecognitionCtor) {
+        setError("Speech recognition is not available in this browser.");
+        return;
+      }
+
+      setError(null);
+      setInterimTranscript("");
+      const recognition = new SpeechRecognitionCtor();
+      recognition.continuous = false;
+      recognition.interimResults = true;
+      recognition.lang = languageCodes[language];
+      recognition.onresult = (event: SpeechRecognitionEvent) => {
+        let finalText = "";
+        let interimText = "";
+        for (let index = event.resultIndex; index < event.results.length; index += 1) {
+          const result = event.results[index];
+          const transcript = result[0]?.transcript ?? "";
+          if (result.isFinal) {
+            finalText += transcript;
+          } else {
+            interimText += transcript;
+          }
+        }
+        setInterimTranscript(interimText.trim());
+        if (finalText.trim()) {
+          finalTranscriptRef.current(finalText.trim());
+        }
+      };
+      recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+        setError(event.message || event.error || "Speech recognition failed.");
+        setIsListening(false);
+      };
+      recognition.onend = () => {
+        setIsListening(false);
+      };
+      recognitionRef.current = recognition;
+      recognition.start();
+      setIsListening(true);
+    },
+    [],
+  );
+
+  const speak = useCallback((text: string, language: Language) => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    if (!("speechSynthesis" in window)) {
+      setError("Speech synthesis is not available in this browser.");
+      return;
+    }
+    window.speechSynthesis.cancel();
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = languageCodes[language];
+    utterance.rate = 0.94;
+    utterance.pitch = 1;
+    window.speechSynthesis.speak(utterance);
+  }, []);
+
+  const cancelSpeech = useCallback(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    if ("speechSynthesis" in window) {
+      window.speechSynthesis.cancel();
+    }
+  }, []);
+
+  return {
+    isRecognitionSupported: speechSupport.recognition,
+    isSynthesisSupported: speechSupport.synthesis,
+    isListening,
+    interimTranscript,
+    error,
+    startListening,
+    stopListening,
+    speak,
+    cancelSpeech,
+  };
+}

--- a/hooks/use-browser-speech.ts
+++ b/hooks/use-browser-speech.ts
@@ -85,8 +85,14 @@ export function useBrowserSpeech(onFinalTranscript: (text: string) => void): Spe
         setIsListening(false);
       };
       recognitionRef.current = recognition;
-      recognition.start();
-      setIsListening(true);
+      try {
+        recognition.start();
+        setIsListening(true);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Speech recognition could not start.";
+        setError(message);
+        setIsListening(false);
+      }
     },
     [],
   );
@@ -99,6 +105,7 @@ export function useBrowserSpeech(onFinalTranscript: (text: string) => void): Spe
       setError("Speech synthesis is not available in this browser.");
       return;
     }
+    setError(null);
     window.speechSynthesis.cancel();
     const utterance = new SpeechSynthesisUtterance(text);
     utterance.lang = languageCodes[language];

--- a/lib/domain.ts
+++ b/lib/domain.ts
@@ -1,0 +1,140 @@
+import { z } from "zod";
+
+export const languageSchema = z.enum([
+  "English",
+  "Spanish",
+  "French",
+  "German",
+  "Hindi",
+  "Japanese",
+  "Korean",
+  "Portuguese",
+  "Italian",
+  "Arabic",
+]);
+
+export const proficiencySchema = z.enum(["Beginner", "Intermediate", "Advanced"]);
+export const practiceModeSchema = z.enum(["Conversation", "Debate"]);
+export const intensitySchema = z.enum(["Gentle", "Focused", "Stretch"]);
+
+export const scenarioConfigSchema = z.object({
+  language: languageSchema,
+  nativeLanguage: languageSchema,
+  proficiency: proficiencySchema,
+  mode: practiceModeSchema,
+  scenario: z.string().trim().min(4).max(280),
+  userRole: z.string().trim().min(2).max(80),
+  partnerRole: z.string().trim().min(2).max(80),
+  goal: z.string().trim().min(4).max(220),
+  culturalFocus: z.string().trim().min(4).max(220),
+  intensity: intensitySchema,
+});
+
+export const messageSchema = z.object({
+  id: z.string().min(1),
+  speaker: z.enum(["user", "partner", "coach"]),
+  content: z.string().min(1).max(1800),
+  createdAt: z.string().min(1),
+});
+
+export const coachFeedbackSchema = z.object({
+  summary: z.string().min(1).max(700),
+  correction: z.string().min(1).max(700),
+  repairedPhrase: z.string().min(1).max(360),
+  encouragement: z.string().min(1).max(360),
+});
+
+export const sessionScoreSchema = z.object({
+  clarity: z.number().min(0).max(100),
+  culturalFit: z.number().min(0).max(100),
+  momentum: z.number().min(0).max(100),
+});
+
+export const tutorTurnResponseSchema = z.object({
+  partnerMessage: z.string().min(1).max(1200),
+  coachFeedback: coachFeedbackSchema,
+  culturalNote: z.string().min(1).max(500),
+  phraseBankAdditions: z.array(z.string().min(1).max(180)).max(6),
+  sessionScore: sessionScoreSchema,
+  provider: z.string().min(1),
+  warning: z.string().optional(),
+});
+
+export const tutorTurnRequestSchema = z.object({
+  config: scenarioConfigSchema,
+  messages: z.array(messageSchema).max(18),
+  userInput: z.string().trim().min(1).max(1200),
+});
+
+export type Language = z.infer<typeof languageSchema>;
+export type Proficiency = z.infer<typeof proficiencySchema>;
+export type PracticeMode = z.infer<typeof practiceModeSchema>;
+export type Intensity = z.infer<typeof intensitySchema>;
+export type ScenarioConfig = z.infer<typeof scenarioConfigSchema>;
+export type ConversationMessage = z.infer<typeof messageSchema>;
+export type CoachFeedback = z.infer<typeof coachFeedbackSchema>;
+export type SessionScore = z.infer<typeof sessionScoreSchema>;
+export type TutorTurnRequest = z.infer<typeof tutorTurnRequestSchema>;
+export type TutorTurnResponse = z.infer<typeof tutorTurnResponseSchema>;
+
+export const languageOptions: Language[] = [
+  "Spanish",
+  "French",
+  "German",
+  "Hindi",
+  "Japanese",
+  "Korean",
+  "Portuguese",
+  "Italian",
+  "Arabic",
+  "English",
+];
+
+export const languageCodes: Record<Language, string> = {
+  English: "en-US",
+  Spanish: "es-ES",
+  French: "fr-FR",
+  German: "de-DE",
+  Hindi: "hi-IN",
+  Japanese: "ja-JP",
+  Korean: "ko-KR",
+  Portuguese: "pt-BR",
+  Italian: "it-IT",
+  Arabic: "ar-SA",
+};
+
+export const defaultScenarioConfig: ScenarioConfig = {
+  language: "Spanish",
+  nativeLanguage: "English",
+  proficiency: "Intermediate",
+  mode: "Conversation",
+  scenario: "You are at a neighborhood pharmacy asking about allergy medicine.",
+  userRole: "Customer with seasonal allergies",
+  partnerRole: "Pharmacist",
+  goal: "Explain symptoms, ask for a recommendation, and confirm dosage politely.",
+  culturalFocus: "Use polite requests, brief context, and a natural closing.",
+  intensity: "Focused",
+};
+
+export function createMessage(
+  speaker: ConversationMessage["speaker"],
+  content: string,
+): ConversationMessage {
+  return {
+    id: globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`,
+    speaker,
+    content,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+export function buildBriefing(config: ScenarioConfig): string {
+  const tone =
+    config.intensity === "Gentle"
+      ? "Keep the pressure low and give the learner extra room."
+      : config.intensity === "Stretch"
+        ? "Increase the pressure with follow-up questions and mild ambiguity."
+        : "Keep the exchange natural and focused.";
+
+  return `${config.language} ${config.proficiency.toLowerCase()} practice: ${config.scenario} Your role is ${config.userRole}; the counterpart is ${config.partnerRole}. Goal: ${config.goal} Cultural focus: ${config.culturalFocus} ${tone}`;
+}

--- a/lib/server/rate-limit.ts
+++ b/lib/server/rate-limit.ts
@@ -1,0 +1,47 @@
+type RateLimitResult =
+  | { allowed: true; remaining: number; resetAt: number }
+  | { allowed: false; remaining: 0; resetAt: number };
+
+type Bucket = {
+  count: number;
+  resetAt: number;
+};
+
+const buckets = new Map<string, Bucket>();
+
+export function checkRateLimit(
+  key: string,
+  options = {
+    limit: 30,
+    windowMs: 60_000,
+  },
+): RateLimitResult {
+  const now = Date.now();
+  const existing = buckets.get(key);
+  if (!existing || existing.resetAt <= now) {
+    const resetAt = now + options.windowMs;
+    buckets.set(key, { count: 1, resetAt });
+    return { allowed: true, remaining: options.limit - 1, resetAt };
+  }
+
+  if (existing.count >= options.limit) {
+    return { allowed: false, remaining: 0, resetAt: existing.resetAt };
+  }
+
+  existing.count += 1;
+  return {
+    allowed: true,
+    remaining: options.limit - existing.count,
+    resetAt: existing.resetAt,
+  };
+}
+
+export function getClientIp(request: Request): string {
+  const forwardedFor = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  const realIp = request.headers.get("x-real-ip")?.trim();
+  return forwardedFor || realIp || "local";
+}
+
+export function resetRateLimitForTests() {
+  buckets.clear();
+}

--- a/lib/tutor/fallback-provider.ts
+++ b/lib/tutor/fallback-provider.ts
@@ -1,0 +1,120 @@
+import type {
+  CoachFeedback,
+  ScenarioConfig,
+  SessionScore,
+  TutorTurnResponse,
+} from "@/lib/domain";
+
+const partnerLines: Record<ScenarioConfig["language"], string[]> = {
+  English: [
+    "I understand. Could you explain one more detail so I can help you better?",
+    "That makes sense. What would you like to do next?",
+  ],
+  Spanish: [
+    "Entiendo. Puede contarme un poco mas para ayudarle mejor?",
+    "Claro. Que prefiere hacer ahora?",
+  ],
+  French: [
+    "Je comprends. Pouvez-vous me donner un peu plus de contexte?",
+    "Bien sur. Qu'est-ce que vous aimeriez faire maintenant?",
+  ],
+  German: [
+    "Ich verstehe. Konnen Sie mir noch ein Detail nennen?",
+    "Naturlich. Was mochten Sie als Nachstes tun?",
+  ],
+  Hindi: [
+    "Samajh gaya. Kripya thoda aur bataiye taaki main madad kar sakun.",
+    "Theek hai. Aap ab kya karna chahenge?",
+  ],
+  Japanese: [
+    "わかりました。もう少し詳しく教えていただけますか。",
+    "そうですね。次にどうしたいですか。",
+  ],
+  Korean: [
+    "알겠습니다. 조금 더 자세히 말씀해 주시겠어요?",
+    "좋습니다. 이제 어떻게 하고 싶으세요?",
+  ],
+  Portuguese: [
+    "Entendo. Pode me dar mais um detalhe para eu ajudar melhor?",
+    "Claro. O que voce gostaria de fazer agora?",
+  ],
+  Italian: [
+    "Capisco. Puo darmi un dettaglio in piu per aiutarla meglio?",
+    "Certo. Che cosa vorrebbe fare adesso?",
+  ],
+  Arabic: [
+    "فهمت. هل يمكنك أن تعطيني تفصيلا إضافيا؟",
+    "حسنا. ماذا تريد أن تفعل الآن؟",
+  ],
+};
+
+export function createFallbackTurn(
+  config: ScenarioConfig,
+  userInput: string,
+  warning?: string,
+): TutorTurnResponse {
+  const shortInput = userInput.trim().slice(0, 140);
+  const lines = partnerLines[config.language];
+  const line = lines[shortInput.length % lines.length];
+  const repairedPhrase = buildRepairPhrase(config);
+  const feedback: CoachFeedback = {
+    summary: `You kept the conversation moving. Now make the turn more specific to the goal: ${config.goal}`,
+    correction: `Try adding one concrete detail instead of a broad answer. Your turn was: "${shortInput}"`,
+    repairedPhrase,
+    encouragement:
+      config.intensity === "Stretch"
+        ? "Stay in the target language and answer the follow-up directly."
+        : "Good momentum. Keep the next answer short and concrete.",
+  };
+  const score: SessionScore = {
+    clarity: Math.min(88, 58 + Math.floor(shortInput.length / 5)),
+    culturalFit: config.culturalFocus.length > 0 ? 72 : 55,
+    momentum: shortInput.split(/\s+/).length >= 4 ? 76 : 58,
+  };
+
+  return {
+    partnerMessage: line,
+    coachFeedback: feedback,
+    culturalNote: `In this scenario, ${config.culturalFocus.toLowerCase()}`,
+    phraseBankAdditions: [repairedPhrase, buildScenarioPhrase(config)],
+    sessionScore: score,
+    provider: "fallback",
+    warning,
+  };
+}
+
+function buildRepairPhrase(config: ScenarioConfig): string {
+  switch (config.language) {
+    case "Spanish":
+      return "Podria recomendarme una opcion adecuada?";
+    case "French":
+      return "Pourriez-vous me recommander une option adaptee?";
+    case "German":
+      return "Konnten Sie mir eine passende Option empfehlen?";
+    case "Hindi":
+      return "Kya aap mujhe ek sahi vikalp bata sakte hain?";
+    case "Japanese":
+      return "合うものをおすすめしていただけますか。";
+    case "Korean":
+      return "저에게 맞는 선택지를 추천해 주실 수 있나요?";
+    case "Portuguese":
+      return "Voce poderia me recomendar uma opcao adequada?";
+    case "Italian":
+      return "Potrebbe consigliarmi un'opzione adatta?";
+    case "Arabic":
+      return "هل يمكنك أن تنصحني بخيار مناسب؟";
+    default:
+      return "Could you recommend a suitable option?";
+  }
+}
+
+function buildScenarioPhrase(config: ScenarioConfig): string {
+  switch (config.proficiency) {
+    case "Beginner":
+      return `I need help with ${config.scenario.split(" ").slice(0, 5).join(" ")}`;
+    case "Advanced":
+      return `I want to handle this with the right tone: ${config.culturalFocus}`;
+    default:
+      return `Can I explain the situation first?`;
+  }
+}

--- a/lib/tutor/fallback-provider.ts
+++ b/lib/tutor/fallback-provider.ts
@@ -48,13 +48,56 @@ const partnerLines: Record<ScenarioConfig["language"], string[]> = {
   ],
 };
 
+const debateLines: Record<ScenarioConfig["language"], string[]> = {
+  English: [
+    "What is your strongest reason for that position?",
+    "I disagree slightly. Can you defend your point with one example?",
+  ],
+  Spanish: [
+    "¿Cuál es su razón más fuerte para esa postura?",
+    "No estoy totalmente de acuerdo. ¿Puede defender su punto con un ejemplo?",
+  ],
+  French: [
+    "Quelle est votre raison la plus forte pour cette position?",
+    "Je ne suis pas tout à fait d'accord. Pouvez-vous défendre votre point avec un exemple?",
+  ],
+  German: [
+    "Was ist Ihr stärkstes Argument für diese Position?",
+    "Ich stimme nicht ganz zu. Können Sie Ihren Punkt mit einem Beispiel verteidigen?",
+  ],
+  Hindi: [
+    "इस राय के लिए आपका सबसे मजबूत कारण क्या है?",
+    "मैं थोड़ा असहमत हूँ। क्या आप एक उदाहरण से अपनी बात समझा सकते हैं?",
+  ],
+  Japanese: [
+    "その意見の一番強い理由は何ですか。",
+    "少し違う意見です。例を一つ使って説明できますか。",
+  ],
+  Korean: [
+    "그 입장에 대한 가장 강한 이유는 무엇인가요?",
+    "저는 조금 다르게 생각합니다. 예를 하나 들어 설명해 주시겠어요?",
+  ],
+  Portuguese: [
+    "Qual é o motivo mais forte para essa posição?",
+    "Não concordo totalmente. Pode defender seu ponto com um exemplo?",
+  ],
+  Italian: [
+    "Qual è la ragione più forte per questa posizione?",
+    "Non sono del tutto d'accordo. Può difendere il suo punto con un esempio?",
+  ],
+  Arabic: [
+    "ما أقوى سبب لديك لهذا الرأي؟",
+    "أنا لا أتفق تماما. هل يمكنك الدفاع عن رأيك بمثال واحد؟",
+  ],
+};
+
 export function createFallbackTurn(
   config: ScenarioConfig,
   userInput: string,
   warning?: string,
 ): TutorTurnResponse {
   const shortInput = userInput.trim().slice(0, 140);
-  const lines = partnerLines[config.language];
+  const lines = config.mode === "Debate" ? debateLines[config.language] : partnerLines[config.language];
   const line = lines[shortInput.length % lines.length];
   const repairedPhrase = buildRepairPhrase(config);
   const feedback = buildCoachFeedback(config, shortInput, repairedPhrase);

--- a/lib/tutor/fallback-provider.ts
+++ b/lib/tutor/fallback-provider.ts
@@ -11,20 +11,20 @@ const partnerLines: Record<ScenarioConfig["language"], string[]> = {
     "That makes sense. What would you like to do next?",
   ],
   Spanish: [
-    "Entiendo. Puede contarme un poco mas para ayudarle mejor?",
-    "Claro. Que prefiere hacer ahora?",
+    "Entiendo. ¿Puede contarme un poco más para ayudarle mejor?",
+    "Claro. ¿Qué prefiere hacer ahora?",
   ],
   French: [
     "Je comprends. Pouvez-vous me donner un peu plus de contexte?",
-    "Bien sur. Qu'est-ce que vous aimeriez faire maintenant?",
+    "Bien sûr. Qu'est-ce que vous aimeriez faire maintenant?",
   ],
   German: [
-    "Ich verstehe. Konnen Sie mir noch ein Detail nennen?",
-    "Naturlich. Was mochten Sie als Nachstes tun?",
+    "Ich verstehe. Können Sie mir noch ein Detail nennen?",
+    "Natürlich. Was möchten Sie als Nächstes tun?",
   ],
   Hindi: [
-    "Samajh gaya. Kripya thoda aur bataiye taaki main madad kar sakun.",
-    "Theek hai. Aap ab kya karna chahenge?",
+    "समझ गया। कृपया थोड़ा और बताइए ताकि मैं बेहतर मदद कर सकूं।",
+    "ठीक है। अब आप क्या करना चाहेंगे?",
   ],
   Japanese: [
     "わかりました。もう少し詳しく教えていただけますか。",
@@ -36,10 +36,10 @@ const partnerLines: Record<ScenarioConfig["language"], string[]> = {
   ],
   Portuguese: [
     "Entendo. Pode me dar mais um detalhe para eu ajudar melhor?",
-    "Claro. O que voce gostaria de fazer agora?",
+    "Claro. O que você gostaria de fazer agora?",
   ],
   Italian: [
-    "Capisco. Puo darmi un dettaglio in piu per aiutarla meglio?",
+    "Capisco. Può darmi un dettaglio in più per aiutarla meglio?",
     "Certo. Che cosa vorrebbe fare adesso?",
   ],
   Arabic: [
@@ -57,15 +57,7 @@ export function createFallbackTurn(
   const lines = partnerLines[config.language];
   const line = lines[shortInput.length % lines.length];
   const repairedPhrase = buildRepairPhrase(config);
-  const feedback: CoachFeedback = {
-    summary: `You kept the conversation moving. Now make the turn more specific to the goal: ${config.goal}`,
-    correction: `Try adding one concrete detail instead of a broad answer. Your turn was: "${shortInput}"`,
-    repairedPhrase,
-    encouragement:
-      config.intensity === "Stretch"
-        ? "Stay in the target language and answer the follow-up directly."
-        : "Good momentum. Keep the next answer short and concrete.",
-  };
+  const feedback = buildCoachFeedback(config, shortInput, repairedPhrase);
   const score: SessionScore = {
     clarity: Math.min(88, 58 + Math.floor(shortInput.length / 5)),
     culturalFit: config.culturalFocus.length > 0 ? 72 : 55,
@@ -75,7 +67,7 @@ export function createFallbackTurn(
   return {
     partnerMessage: line,
     coachFeedback: feedback,
-    culturalNote: `In this scenario, ${config.culturalFocus.toLowerCase()}`,
+    culturalNote: buildCulturalNote(config),
     phraseBankAdditions: [repairedPhrase, buildScenarioPhrase(config)],
     sessionScore: score,
     provider: "fallback",
@@ -83,22 +75,58 @@ export function createFallbackTurn(
   };
 }
 
+function buildCoachFeedback(
+  config: ScenarioConfig,
+  shortInput: string,
+  repairedPhrase: string,
+): CoachFeedback {
+  if (config.nativeLanguage === "Hindi") {
+    return {
+      summary: "आपने बातचीत जारी रखी। अब अपना उद्देश्य और स्पष्ट करें।",
+      correction: `एक ठोस जानकारी जोड़ें। आपका उत्तर था: "${shortInput}"`,
+      repairedPhrase,
+      encouragement:
+        config.intensity === "Stretch"
+          ? "लक्ष्य भाषा में रहें और अगले सवाल का सीधे जवाब दें।"
+          : "अच्छी शुरुआत। अगला उत्तर छोटा और स्पष्ट रखें।",
+    };
+  }
+
+  return {
+    summary: `You kept the conversation moving. Now make the turn more specific to the goal: ${config.goal}`,
+    correction: `Try adding one concrete detail instead of a broad answer. Your turn was: "${shortInput}"`,
+    repairedPhrase,
+    encouragement:
+      config.intensity === "Stretch"
+        ? "Stay in the target language and answer the follow-up directly."
+        : "Good momentum. Keep the next answer short and concrete.",
+  };
+}
+
+function buildCulturalNote(config: ScenarioConfig): string {
+  if (config.nativeLanguage === "Hindi") {
+    return "इस स्थिति में विनम्र अभिवादन और सम्मानजनक अनुरोध पर ध्यान दें।";
+  }
+
+  return `In this scenario, ${config.culturalFocus.toLowerCase()}`;
+}
+
 function buildRepairPhrase(config: ScenarioConfig): string {
   switch (config.language) {
     case "Spanish":
-      return "Podria recomendarme una opcion adecuada?";
+      return "¿Podría recomendarme una opción adecuada?";
     case "French":
-      return "Pourriez-vous me recommander une option adaptee?";
+      return "Pourriez-vous me recommander une option adaptée?";
     case "German":
-      return "Konnten Sie mir eine passende Option empfehlen?";
+      return "Könnten Sie mir eine passende Option empfehlen?";
     case "Hindi":
-      return "Kya aap mujhe ek sahi vikalp bata sakte hain?";
+      return "क्या आप मुझे एक उचित विकल्प सुझा सकते हैं?";
     case "Japanese":
       return "合うものをおすすめしていただけますか。";
     case "Korean":
       return "저에게 맞는 선택지를 추천해 주실 수 있나요?";
     case "Portuguese":
-      return "Voce poderia me recomendar uma opcao adequada?";
+      return "Você poderia me recomendar uma opção adequada?";
     case "Italian":
       return "Potrebbe consigliarmi un'opzione adatta?";
     case "Arabic":
@@ -109,12 +137,58 @@ function buildRepairPhrase(config: ScenarioConfig): string {
 }
 
 function buildScenarioPhrase(config: ScenarioConfig): string {
-  switch (config.proficiency) {
-    case "Beginner":
-      return `I need help with ${config.scenario.split(" ").slice(0, 5).join(" ")}`;
-    case "Advanced":
-      return `I want to handle this with the right tone: ${config.culturalFocus}`;
-    default:
-      return `Can I explain the situation first?`;
-  }
+  const phrases: Record<ScenarioConfig["language"], Record<ScenarioConfig["proficiency"], string>> = {
+    English: {
+      Beginner: "I need help with this.",
+      Intermediate: "Can I explain the situation first?",
+      Advanced: "I want to handle this with the right tone.",
+    },
+    Spanish: {
+      Beginner: "Necesito ayuda con esto.",
+      Intermediate: "¿Puedo explicar primero la situación?",
+      Advanced: "Quiero manejar esto con el tono adecuado.",
+    },
+    French: {
+      Beginner: "J'ai besoin d'aide avec cela.",
+      Intermediate: "Puis-je d'abord expliquer la situation?",
+      Advanced: "Je veux gérer cela avec le ton approprié.",
+    },
+    German: {
+      Beginner: "Ich brauche dabei Hilfe.",
+      Intermediate: "Kann ich zuerst die Situation erklären?",
+      Advanced: "Ich möchte das mit dem richtigen Ton angehen.",
+    },
+    Hindi: {
+      Beginner: "मुझे इसमें मदद चाहिए।",
+      Intermediate: "क्या मैं पहले स्थिति समझा सकता हूँ?",
+      Advanced: "मैं इसे सही लहजे में संभालना चाहता हूँ।",
+    },
+    Japanese: {
+      Beginner: "これについて助けが必要です。",
+      Intermediate: "まず状況を説明してもいいですか。",
+      Advanced: "適切な口調で対応したいです。",
+    },
+    Korean: {
+      Beginner: "이 일에 도움이 필요합니다.",
+      Intermediate: "먼저 상황을 설명해도 될까요?",
+      Advanced: "적절한 말투로 대응하고 싶습니다.",
+    },
+    Portuguese: {
+      Beginner: "Preciso de ajuda com isso.",
+      Intermediate: "Posso explicar a situação primeiro?",
+      Advanced: "Quero lidar com isso no tom adequado.",
+    },
+    Italian: {
+      Beginner: "Ho bisogno di aiuto con questo.",
+      Intermediate: "Posso spiegare prima la situazione?",
+      Advanced: "Voglio gestire la cosa con il tono giusto.",
+    },
+    Arabic: {
+      Beginner: "أحتاج إلى مساعدة في هذا.",
+      Intermediate: "هل يمكنني شرح الموقف أولا؟",
+      Advanced: "أريد التعامل مع هذا بالنبرة المناسبة.",
+    },
+  };
+
+  return phrases[config.language][config.proficiency];
 }

--- a/lib/tutor/prompt.ts
+++ b/lib/tutor/prompt.ts
@@ -1,0 +1,62 @@
+import type { ConversationMessage, ScenarioConfig } from "@/lib/domain";
+
+export function buildTutorPrompt(
+  config: ScenarioConfig,
+  messages: ConversationMessage[],
+  userInput: string,
+): string {
+  const history = messages
+    .slice(-10)
+    .map((message) => `${message.speaker.toUpperCase()}: ${message.content}`)
+    .join("\n");
+
+  return `
+You are Parrot-AI, a language tutor and role-play counterpart.
+
+Target language: ${config.language}
+Learner native language: ${config.nativeLanguage}
+Proficiency: ${config.proficiency}
+Mode: ${config.mode}
+Scenario: ${config.scenario}
+Learner role: ${config.userRole}
+Counterpart role: ${config.partnerRole}
+Session goal: ${config.goal}
+Cultural focus: ${config.culturalFocus}
+Intensity: ${config.intensity}
+
+Rules:
+- Speak as the counterpart, not as a narrator.
+- Keep the partner message in ${config.language}.
+- Keep the partner message concise and realistic.
+- Do not solve the whole conversation for the learner.
+- Ask a follow-up that forces the learner to respond.
+- Give coaching feedback in ${config.nativeLanguage}.
+- Feedback should be repair-focused, not just evaluative.
+- Cultural note must be concrete and tied to the current turn.
+- Return only valid JSON matching the schema.
+
+Recent conversation:
+${history || "(no prior messages)"}
+
+Learner latest turn:
+${userInput}
+
+JSON schema:
+{
+  "partnerMessage": "string",
+  "coachFeedback": {
+    "summary": "string",
+    "correction": "string",
+    "repairedPhrase": "string",
+    "encouragement": "string"
+  },
+  "culturalNote": "string",
+  "phraseBankAdditions": ["string"],
+  "sessionScore": {
+    "clarity": 0,
+    "culturalFit": 0,
+    "momentum": 0
+  }
+}
+`.trim();
+}

--- a/lib/tutor/provider.ts
+++ b/lib/tutor/provider.ts
@@ -1,0 +1,107 @@
+import type {
+  ConversationMessage,
+  ScenarioConfig,
+  TutorTurnResponse,
+} from "@/lib/domain";
+import { createFallbackTurn } from "@/lib/tutor/fallback-provider";
+import { buildTutorPrompt } from "@/lib/tutor/prompt";
+import { parseProviderResponse } from "@/lib/tutor/response-parser";
+
+type ProviderName = "fallback" | "ollama";
+
+type ProviderInput = {
+  config: ScenarioConfig;
+  messages: ConversationMessage[];
+  userInput: string;
+};
+
+export async function runTutorProvider(
+  input: ProviderInput,
+): Promise<TutorTurnResponse> {
+  const provider = getProviderName();
+  if (provider === "ollama") {
+    return runOllamaProvider(input);
+  }
+
+  return createFallbackTurn(input.config, input.userInput);
+}
+
+export function getProviderName(): ProviderName {
+  const provider = (process.env.TUTOR_PROVIDER ?? process.env.AI_PROVIDER)?.toLowerCase();
+  if (provider === "ollama") {
+    return "ollama";
+  }
+  if (provider === "fallback") {
+    return "fallback";
+  }
+  if (process.env.OLLAMA_MODEL || process.env.OLLAMA_BASE_URL) {
+    return "ollama";
+  }
+  return "fallback";
+}
+
+async function runOllamaProvider({
+  config,
+  messages,
+  userInput,
+}: ProviderInput): Promise<TutorTurnResponse> {
+  const baseUrl = process.env.OLLAMA_BASE_URL ?? "http://localhost:11434";
+  const model = process.env.OLLAMA_MODEL ?? "qwen3:8b";
+  const prompt = buildTutorPrompt(config, messages, userInput);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 22_000);
+
+  try {
+    const response = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          {
+            role: "system",
+            content:
+              "You are a precise language tutor. Return only valid JSON.",
+          },
+          { role: "user", content: prompt },
+        ],
+        temperature: 0.7,
+        stream: false,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      return createFallbackTurn(
+        config,
+        userInput,
+        `Ollama returned ${response.status}; fallback response used.`,
+      );
+    }
+
+    const json = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const rawText = json.choices?.[0]?.message?.content;
+    if (!rawText) {
+      return createFallbackTurn(
+        config,
+        userInput,
+        "Ollama returned an empty message; fallback response used.",
+      );
+    }
+    return parseProviderResponse(rawText, config, userInput, "ollama");
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unknown Ollama provider error.";
+    return createFallbackTurn(
+      config,
+      userInput,
+      `Ollama unavailable (${message}); fallback response used.`,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/lib/tutor/response-parser.ts
+++ b/lib/tutor/response-parser.ts
@@ -1,0 +1,66 @@
+import {
+  tutorTurnResponseSchema,
+  type ScenarioConfig,
+  type TutorTurnResponse,
+} from "@/lib/domain";
+import { createFallbackTurn } from "@/lib/tutor/fallback-provider";
+
+export function parseProviderResponse(
+  rawText: string,
+  config: ScenarioConfig,
+  userInput: string,
+  provider: string,
+): TutorTurnResponse {
+  const parsed = tryParseJson(rawText);
+  if (!parsed) {
+    return createFallbackTurn(
+      config,
+      userInput,
+      `${provider} returned non-JSON output; fallback response used.`,
+    );
+  }
+
+  const candidate = {
+    ...parsed,
+    provider,
+  };
+  const result = tutorTurnResponseSchema.safeParse(candidate);
+  if (!result.success) {
+    return createFallbackTurn(
+      config,
+      userInput,
+      `${provider} returned an invalid response shape; fallback response used.`,
+    );
+  }
+
+  return result.data;
+}
+
+function tryParseJson(rawText: string): unknown | null {
+  const trimmed = rawText.trim();
+  const extracted = extractJsonObject(trimmed);
+  const candidates = [
+    trimmed,
+    trimmed.replace(/^```json\s*/i, "").replace(/```$/i, "").trim(),
+    ...(extracted ? [extracted] : []),
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+function extractJsonObject(text: string): string | null {
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) {
+    return null;
+  }
+  return text.slice(start, end + 1);
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,8 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  devIndicators: false,
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,32 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   devIndicators: false,
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          {
+            key: "X-Content-Type-Options",
+            value: "nosniff",
+          },
+          {
+            key: "X-Frame-Options",
+            value: "DENY",
+          },
+          {
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
+          },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), geolocation=(), microphone=(self)",
+          },
+        ],
+      },
+    ];
+  },
+  poweredByHeader: false,
   reactStrictMode: true,
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3135 @@
+{
+  "name": "parrot-ai",
+  "version": "2.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "parrot-ai",
+      "version": "2.0.0",
+      "dependencies": {
+        "lucide-react": "^1.17.0",
+        "next": "^16.2.7",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "zod": "^4.4.3"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.60.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/node": "^24.10.2",
+        "@types/react": "^19.2.7",
+        "@types/react-dom": "^19.2.3",
+        "jsdom": "^27.3.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.8"
+      }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.7.tgz",
+      "integrity": "sha512-tMJizPlj6ZYpBMMdK8S0LJufrP4QTdR6pcv9KQ/bVETPAmg0j1mlHE9G2c38UyGHxoBapgwuj7XjbGJ2RcDFOg==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.7.tgz",
+      "integrity": "sha512-vm1EDI/pVaBNNiychmxk3fft+OhQPVD9cIM/tReLZIQ3TfQ4kqI9DwKk00dzuS1ulC7icbrzCFrmRRlk9PfNdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.7.tgz",
+      "integrity": "sha512-O3IRSv1ZBL1zs0WrIgefTEcTKFVn+ryxBNe54erJ6KsD+2f/Mmt7g2jOYh8PSBdUwPtKQJuCsTMlZ7tIu2AcsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.7.tgz",
+      "integrity": "sha512-Re6PZtjBDd0aMU+VcZcC/PrIvj4WhrjDYtMhhCVQamWN4L90EVP0pcEOBQD25prSlw7OzNw5QpHLWMilRLsRNw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.7.tgz",
+      "integrity": "sha512-qyogG9QtBzWxgJfeGBvOEHI3851gTfCF3wLZ5RDLTBJGAmE9p1qDwKCOdrBrvBzRvYDT+gUDp72pzlSEfAXgNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.7.tgz",
+      "integrity": "sha512-Vhe4ZDuBpmMogrGi5D4R2Kq4JAQlj6+wvgaFYy31zfES0zPmt6TLA+cuYpM/OLrPZjo2MYQTHVqNUSCR6+fDZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.7.tgz",
+      "integrity": "sha512-srvian89JahFLw1YLBEuhvPJ0DO5lpUeJQMXy4xYo7g628ZlNgXdNkqoxSAv9OYrBfByh6vxISMwW/mRbzCY+g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.7.tgz",
+      "integrity": "sha512-GX3wvLpULFuRFJzwHaKfm7QZJ18F4ZSuxlPJ96BoBglCzBmdSjyeBKF+ZhWhvL/ckxNfLnNa7bsObO2ipYpszw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.7.tgz",
+      "integrity": "sha512-J4WlM72NMk076Qsg0jTdK3SNXatlSdnjW7L7oNGLst1tAGjHrJh/FYi+pw9wyIjEtGRKDNzD0zuiY16oWYWVaw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
+      "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.34",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz",
+      "integrity": "sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001797",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/jsdom": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.17.0.tgz",
+      "integrity": "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.7.tgz",
+      "integrity": "sha512-eMJxgjRzBaj3olkP4cBamHDXL79A8FC6u1GcsO1D1Tsx8bw/LLXUJCaoajVxtnhD3A1IJqIT8IcRJjgBIPJq4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.2.7",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.2.7",
+        "@next/swc-darwin-x64": "16.2.7",
+        "@next/swc-linux-arm64-gnu": "16.2.7",
+        "@next/swc-linux-arm64-musl": "16.2.7",
+        "@next/swc-linux-x64-gnu": "16.2.7",
+        "@next/swc-linux-x64-musl": "16.2.7",
+        "@next/swc-win32-arm64-msvc": "16.2.7",
+        "@next/swc-win32-x64-msvc": "16.2.7",
+        "sharp": "^0.34.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2400,9 +2400,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -2419,9 +2419,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -2898,35 +2898,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.12",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "parrot-ai",
+  "version": "2.0.0",
+  "private": true,
+  "description": "Conversation-first language learning app.",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "e2e": "playwright test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "lucide-react": "^1.17.0",
+    "next": "^16.2.7",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.60.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/node": "^24.10.2",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "jsdom": "^27.3.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "react-dom": "^19.2.7",
     "zod": "^4.4.3"
   },
+  "overrides": {
+    "postcss": "^8.5.15"
+  },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.9.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "mobile",
+      use: { ...devices["Pixel 7"] },
+    },
+  ],
+});

--- a/tests/e2e/parrot.spec.ts
+++ b/tests/e2e/parrot.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test";
+
+test("completes a typed conversation turn", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: "Parrot-AI" })).toBeVisible();
+  await expect(page.getByLabel("Target language")).toBeVisible();
+  await expect(page.getByText("Learning Coach")).toBeVisible();
+
+  await page.getByLabel("Your response").fill("Tengo alergias y necesito una medicina.");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  await expect(
+    page.getByLabel("Conversation messages").getByText("Tengo alergias y necesito una medicina.", {
+      exact: true,
+    }),
+  ).toBeVisible();
+  await expect(page.getByText("Repair")).toBeVisible();
+  await expect(page.getByText("Phrase bank")).toBeVisible();
+  await expect(page.getByLabel("Phrase bank").getByText("Can I explain the situation first?")).toBeVisible();
+});
+
+test("mobile layout keeps the workspace usable", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: "Parrot-AI" })).toBeVisible();
+  await expect(page.getByLabel("Situation")).toBeVisible();
+  await expect(page.getByLabel("Your response")).toBeVisible();
+});

--- a/tests/e2e/parrot.spec.ts
+++ b/tests/e2e/parrot.spec.ts
@@ -16,8 +16,9 @@ test("completes a typed conversation turn", async ({ page }) => {
     }),
   ).toBeVisible();
   await expect(page.getByText("Repair")).toBeVisible();
+  await expect(page.getByText("Culture note")).toBeVisible();
   await expect(page.getByText("Phrase bank")).toBeVisible();
-  await expect(page.getByLabel("Phrase bank").getByText("Can I explain the situation first?")).toBeVisible();
+  await expect(page.getByLabel("Phrase bank").getByText("¿Puedo explicar primero la situación?")).toBeVisible();
 });
 
 test("mobile layout keeps the workspace usable", async ({ page }) => {

--- a/tests/integration/health-route.test.ts
+++ b/tests/integration/health-route.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { GET } from "@/app/api/health/route";
+
+describe("/api/health", () => {
+  it("returns service health", async () => {
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.provider).toBeTruthy();
+    expect(Date.parse(json.timestamp)).not.toBeNaN();
+  });
+});

--- a/tests/integration/tutor-route.test.ts
+++ b/tests/integration/tutor-route.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { defaultScenarioConfig, createMessage } from "@/lib/domain";
 import { POST } from "@/app/api/tutor/turn/route";
+import { resetRateLimitForTests } from "@/lib/server/rate-limit";
 
 describe("/api/tutor/turn", () => {
+  beforeEach(() => {
+    resetRateLimitForTests();
+  });
+
   it("returns a fallback tutor turn for a valid request", async () => {
     const request = new Request("http://localhost/api/tutor/turn", {
       method: "POST",
@@ -34,5 +39,29 @@ describe("/api/tutor/turn", () => {
     const response = await POST(request);
 
     expect(response.status).toBe(400);
+  });
+
+  it("rate limits repeated tutor requests from the same client", async () => {
+    const body = JSON.stringify({
+      config: defaultScenarioConfig,
+      messages: [],
+      userInput: "Tengo alergias y necesito medicina.",
+    });
+
+    let response: Response | null = null;
+    for (let index = 0; index < 31; index += 1) {
+      response = await POST(
+        new Request("http://localhost/api/tutor/turn", {
+          method: "POST",
+          headers: {
+            "x-forwarded-for": "203.0.113.9",
+          },
+          body,
+        }),
+      );
+    }
+
+    expect(response?.status).toBe(429);
+    expect(response?.headers.get("Retry-After")).toBeTruthy();
   });
 });

--- a/tests/integration/tutor-route.test.ts
+++ b/tests/integration/tutor-route.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { defaultScenarioConfig, createMessage } from "@/lib/domain";
+import { POST } from "@/app/api/tutor/turn/route";
+
+describe("/api/tutor/turn", () => {
+  it("returns a fallback tutor turn for a valid request", async () => {
+    const request = new Request("http://localhost/api/tutor/turn", {
+      method: "POST",
+      body: JSON.stringify({
+        config: defaultScenarioConfig,
+        messages: [createMessage("partner", "Hola, en que puedo ayudarle?")],
+        userInput: "Tengo alergias y necesito medicina.",
+      }),
+    });
+
+    const response = await POST(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.partnerMessage).toBeTruthy();
+    expect(json.coachFeedback.repairedPhrase).toBeTruthy();
+  });
+
+  it("rejects empty user input", async () => {
+    const request = new Request("http://localhost/api/tutor/turn", {
+      method: "POST",
+      body: JSON.stringify({
+        config: defaultScenarioConfig,
+        messages: [],
+        userInput: "",
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/tests/unit/domain.test.ts
+++ b/tests/unit/domain.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildBriefing,
+  defaultScenarioConfig,
+  scenarioConfigSchema,
+} from "@/lib/domain";
+
+describe("domain model", () => {
+  it("keeps the default scenario valid", () => {
+    expect(scenarioConfigSchema.safeParse(defaultScenarioConfig).success).toBe(true);
+  });
+
+  it("builds a briefing with language, goal, and cultural focus", () => {
+    const briefing = buildBriefing(defaultScenarioConfig);
+
+    expect(briefing).toContain("Spanish");
+    expect(briefing).toContain(defaultScenarioConfig.goal);
+    expect(briefing).toContain(defaultScenarioConfig.culturalFocus);
+  });
+});

--- a/tests/unit/fallback-provider.test.ts
+++ b/tests/unit/fallback-provider.test.ts
@@ -36,4 +36,18 @@ describe("createFallbackTurn", () => {
     expect(response.culturalNote).toMatch(/[\u0900-\u097F]/);
     expect(response.phraseBankAdditions.join(" ")).toMatch(/[\u0900-\u097F]/);
   });
+
+  it("changes the demo partner behavior for debate mode", () => {
+    const conversation = createFallbackTurn(
+      { ...defaultScenarioConfig, language: "English", mode: "Conversation" },
+      "I think this option is better.",
+    );
+    const debate = createFallbackTurn(
+      { ...defaultScenarioConfig, language: "English", mode: "Debate" },
+      "I think this option is better.",
+    );
+
+    expect(debate.partnerMessage).not.toBe(conversation.partnerMessage);
+    expect(debate.partnerMessage).toMatch(/reason|defend/i);
+  });
 });

--- a/tests/unit/fallback-provider.test.ts
+++ b/tests/unit/fallback-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { defaultScenarioConfig, tutorTurnResponseSchema } from "@/lib/domain";
+import { defaultScenarioConfig, languageOptions, tutorTurnResponseSchema } from "@/lib/domain";
 import { createFallbackTurn } from "@/lib/tutor/fallback-provider";
 
 describe("createFallbackTurn", () => {
@@ -9,5 +9,31 @@ describe("createFallbackTurn", () => {
     expect(tutorTurnResponseSchema.safeParse(response).success).toBe(true);
     expect(response.provider).toBe("fallback");
     expect(response.phraseBankAdditions.length).toBeGreaterThan(0);
+  });
+
+  it("returns valid fallback turns for every target language", () => {
+    for (const language of languageOptions) {
+      const response = createFallbackTurn(
+        { ...defaultScenarioConfig, language },
+        "I need help with this.",
+      );
+
+      expect(tutorTurnResponseSchema.safeParse(response).success).toBe(true);
+      expect(response.partnerMessage.length).toBeGreaterThan(0);
+      expect(response.phraseBankAdditions).toHaveLength(2);
+    }
+  });
+
+  it("uses Devanagari text for Hindi fallback practice", () => {
+    const response = createFallbackTurn(
+      { ...defaultScenarioConfig, language: "Hindi", nativeLanguage: "Hindi" },
+      "मुझे एलर्जी है।",
+    );
+
+    expect(response.partnerMessage).toMatch(/[\u0900-\u097F]/);
+    expect(response.coachFeedback.summary).toMatch(/[\u0900-\u097F]/);
+    expect(response.coachFeedback.repairedPhrase).toMatch(/[\u0900-\u097F]/);
+    expect(response.culturalNote).toMatch(/[\u0900-\u097F]/);
+    expect(response.phraseBankAdditions.join(" ")).toMatch(/[\u0900-\u097F]/);
   });
 });

--- a/tests/unit/fallback-provider.test.ts
+++ b/tests/unit/fallback-provider.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { defaultScenarioConfig, tutorTurnResponseSchema } from "@/lib/domain";
+import { createFallbackTurn } from "@/lib/tutor/fallback-provider";
+
+describe("createFallbackTurn", () => {
+  it("returns a valid structured tutor response", () => {
+    const response = createFallbackTurn(defaultScenarioConfig, "Tengo alergias.");
+
+    expect(tutorTurnResponseSchema.safeParse(response).success).toBe(true);
+    expect(response.provider).toBe("fallback");
+    expect(response.phraseBankAdditions.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/prompt.test.ts
+++ b/tests/unit/prompt.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { createMessage, defaultScenarioConfig } from "@/lib/domain";
+import { buildTutorPrompt } from "@/lib/tutor/prompt";
+
+describe("buildTutorPrompt", () => {
+  it("includes scenario context and JSON instructions", () => {
+    const prompt = buildTutorPrompt(
+      defaultScenarioConfig,
+      [createMessage("user", "Tengo alergias.")],
+      "Necesito ayuda.",
+    );
+
+    expect(prompt).toContain(defaultScenarioConfig.language);
+    expect(prompt).toContain(defaultScenarioConfig.partnerRole);
+    expect(prompt).toContain("Return only valid JSON");
+    expect(prompt).toContain("Necesito ayuda.");
+  });
+});

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getProviderName } from "@/lib/tutor/provider";
+
+describe("getProviderName", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses fallback by default", () => {
+    expect(getProviderName()).toBe("fallback");
+  });
+
+  it("uses the documented tutor provider env var", () => {
+    vi.stubEnv("TUTOR_PROVIDER", "ollama");
+
+    expect(getProviderName()).toBe("ollama");
+  });
+
+  it("auto-selects ollama when a local model is configured", () => {
+    vi.stubEnv("OLLAMA_MODEL", "qwen3:8b");
+
+    expect(getProviderName()).toBe("ollama");
+  });
+
+  it("keeps the legacy provider env var working", () => {
+    vi.stubEnv("AI_PROVIDER", "ollama");
+
+    expect(getProviderName()).toBe("ollama");
+  });
+});

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  checkRateLimit,
+  getClientIp,
+  resetRateLimitForTests,
+} from "@/lib/server/rate-limit";
+
+describe("rate limiting", () => {
+  beforeEach(() => {
+    resetRateLimitForTests();
+  });
+
+  it("allows requests until the configured limit is reached", () => {
+    expect(checkRateLimit("client-a", { limit: 2, windowMs: 60_000 }).allowed).toBe(true);
+    expect(checkRateLimit("client-a", { limit: 2, windowMs: 60_000 }).allowed).toBe(true);
+
+    const blocked = checkRateLimit("client-a", { limit: 2, windowMs: 60_000 });
+
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.remaining).toBe(0);
+  });
+
+  it("prefers forwarded client IP headers", () => {
+    const request = new Request("http://localhost", {
+      headers: {
+        "x-forwarded-for": "203.0.113.1, 203.0.113.2",
+        "x-real-ip": "198.51.100.1",
+      },
+    });
+
+    expect(getClientIp(request)).toBe("203.0.113.1");
+  });
+});

--- a/tests/unit/response-parser.test.ts
+++ b/tests/unit/response-parser.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { defaultScenarioConfig } from "@/lib/domain";
+import { parseProviderResponse } from "@/lib/tutor/response-parser";
+
+describe("parseProviderResponse", () => {
+  it("parses valid JSON", () => {
+    const response = parseProviderResponse(
+      JSON.stringify({
+        partnerMessage: "Claro, puedo ayudarle.",
+        coachFeedback: {
+          summary: "Good.",
+          correction: "Add one detail.",
+          repairedPhrase: "Tengo alergias desde ayer.",
+          encouragement: "Keep going.",
+        },
+        culturalNote: "Polite requests fit this setting.",
+        phraseBankAdditions: ["Tengo alergias desde ayer."],
+        sessionScore: {
+          clarity: 80,
+          culturalFit: 75,
+          momentum: 78,
+        },
+      }),
+      defaultScenarioConfig,
+      "Tengo alergias.",
+      "test",
+    );
+
+    expect(response.provider).toBe("test");
+    expect(response.partnerMessage).toContain("Claro");
+  });
+
+  it("falls back on malformed JSON", () => {
+    const response = parseProviderResponse(
+      "not json",
+      defaultScenarioConfig,
+      "Tengo alergias.",
+      "test",
+    );
+
+    expect(response.provider).toBe("fallback");
+    expect(response.warning).toContain("non-JSON");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,42 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2022"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "legacy"
+  ]
+}

--- a/types/speech.d.ts
+++ b/types/speech.d.ts
@@ -1,0 +1,47 @@
+interface SpeechRecognitionAlternative {
+  transcript: string;
+  confidence: number;
+}
+
+interface SpeechRecognitionResult {
+  readonly isFinal: boolean;
+  readonly length: number;
+  item(index: number): SpeechRecognitionAlternative;
+  [index: number]: SpeechRecognitionAlternative;
+}
+
+interface SpeechRecognitionResultList {
+  readonly length: number;
+  item(index: number): SpeechRecognitionResult;
+  [index: number]: SpeechRecognitionResult;
+}
+
+interface SpeechRecognitionEvent extends Event {
+  readonly resultIndex: number;
+  readonly results: SpeechRecognitionResultList;
+}
+
+interface SpeechRecognitionErrorEvent extends Event {
+  readonly error: string;
+  readonly message: string;
+}
+
+interface SpeechRecognition extends EventTarget {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onend: (() => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEvent) => void) | null;
+  onresult: ((event: SpeechRecognitionEvent) => void) | null;
+  start(): void;
+  stop(): void;
+}
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognition;
+}
+
+interface Window {
+  SpeechRecognition?: SpeechRecognitionConstructor;
+  webkitSpeechRecognition?: SpeechRecognitionConstructor;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./vitest.setup.ts"],
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
+  },
+  resolve: {
+    alias: {
+      "@": new URL(".", import.meta.url).pathname,
+    },
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
- Replaces the Streamlit-first proof of concept with a Next.js conversation practice app.
- Adds Scenario Studio, Conversation Workspace, Learning Coach, browser speech support, local persistence, deterministic fallback tutoring, and optional Ollama provider support.
- Adds overhaul research/product/engineering/test docs plus CI for typecheck, unit/integration tests, build, and Playwright.

## Verification
- npm run typecheck
- npm test
- npm run e2e
- npm run build
- desktop and mobile visual QA with Playwright screenshots

## Notes
- The app runs without paid API keys by default.
- Optional local model path: install Ollama and set OLLAMA_MODEL, or set TUTOR_PROVIDER=ollama.
- npm audit still reports a moderate postcss advisory through current Next; the suggested force fix downgrades Next to 9.3.3, so it was not applied.
